### PR TITLE
Modify setup to find and complete paths in config.lua

### DIFF
--- a/plugin/demo_config.lua
+++ b/plugin/demo_config.lua
@@ -1,0 +1,14 @@
+local _M = {}
+
+-- user settings
+_M.python_executable = "/home/martin/anaconda3/envs/xournalpp_htr/bin/python"
+_M.xournalpp_htr_path = "/home/martin/Development/xournalpp_htr/xournalpp_htr/run_htr.py"
+_M.model = "dummy"
+_M.output_file = "/home/martin/Development/xournalpp_htr/tests/test_1_from_Xpp.pdf"
+_M.debug_HTR_command = false
+-- TODO: allow UI to set other parameters as well of `xournalpp_htr`.
+
+-- TODO replace later w/ temp exported file - filename will be derived automatically
+_M.filename = "/home/martin/Development/xournalpp_htr/tests/test_1.xoj"
+
+return _M

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,40 @@
+import os
+import sys
+
 import setuptools
+
+## Modifies config.lua to use the appropriate paths
+# Get the path of this file
+htr_dir = os.path.dirname(os.path.abspath(__file__))
+
+# Path to the config.lua file
+config_file = os.path.join(htr_dir, "plugin", "config.lua")
+
+# Fix direction of slashes, needed on Windows
+htr_dir = htr_dir.replace("\\", "/")
+
+# Get the path of the Python executable
+python_executable = sys.executable.replace("\\", "/")
+
+# Modify the config.lua file
+with open(config_file, "r") as f:
+    lines = f.readlines()
+
+# Modify the necessary lines in the config.lua file
+modified_lines = []
+for line in lines:
+    if line.startswith("_M.python_executable ="):
+        modified_lines.append('_M.python_executable = "' + python_executable + '"\n')
+    elif line.startswith("_M.xournalpp_htr_path ="):
+        modified_lines.append(
+            '_M.xournalpp_htr_path = "' + htr_dir + '/xournalpp_htr/run_htr.py"\n'
+        )
+    else:
+        modified_lines.append(line)
+
+# Write the modified lines back to the config.lua file
+with open(config_file, "w") as f:
+    f.writelines(modified_lines)
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
This should render steps 6 in the [README](README.md) obsolete. That instruction is added in #10 .

I tested it on my Windows machine and it worked flawlessly, but it should be checked on Linux and Mac if there is access.