### PR TITLE
Fix text selection alignment in exported PDFs

### DIFF
--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -161,6 +161,7 @@ def document_to_HTR_document_and_image_of_first_page(document_path, session_id):
         pdf_with_htr,
         predictions,
         debug_htr=True,
+        small_text=False,
     )  # TODO: make it a generator to track progress externally like here.
     images = convert_from_path(pdf_with_htr, first_page=1, last_page=1)
     first_page = images[0]

--- a/tests/test_run_htr.py
+++ b/tests/test_run_htr.py
@@ -31,7 +31,7 @@ def test_parse_arguments_full() -> None:
     parses a complete set of command-line arguments.
     """
     args = parse_arguments("-if input -of output -p dummy -pid dir -sp")
-    assert len(args) == 5
+    assert len(args) == 6
     assert args["input_file"].stem == "input"
     assert args["output_file"].stem == "output"
     assert args["pipeline"] == "dummy"
@@ -58,6 +58,7 @@ def test_main(get_path_to_minimal_test_data: Path, tmp_path: Path) -> None:
         "pipeline": "2024-07-18_htr_pipeline",  # TODO: Add a `dummy` to test pipeline w/o ML part
         "prediction_image_dir": None,
         "show_predictions": False,
+        "small_text": False,
     }
 
     export_xournalpp_to_pdf_with_htr(args)

--- a/xournalpp_htr/shortcuts.py
+++ b/xournalpp_htr/shortcuts.py
@@ -30,6 +30,7 @@ def export_xournalpp_to_pdf_with_htr(args: dict) -> None:
     prediction_image_dir = args["prediction_image_dir"]
     output_file = args["output_file"]
     debug_htr = args["show_predictions"]
+    small_text = args["small_text"]
     pipeline = args["pipeline"]
 
     output_file_tmp_noOCR = get_temporary_filename()
@@ -57,6 +58,7 @@ def export_xournalpp_to_pdf_with_htr(args: dict) -> None:
         output_file,
         predictions,
         debug_htr,
+        small_text,
     )
 
     print("xournalpp_htr: Done!")

--- a/xournalpp_htr/utils.py
+++ b/xournalpp_htr/utils.py
@@ -101,6 +101,13 @@ def parse_arguments(cli_string: None | str = None):
         "Useful for debugging purposes. "
         "Otherwise only store invisible text.",
     )
+    parser.add_argument(
+        "--small-text",
+        action="store_true",
+        help="Use a fixed small font size (6pt) for prediction text instead of "
+        "scaling text to fill the bounding box. "
+        "Useful with --show-predictions to reduce visual clutter.",
+    )
     args = vars(parser.parse_args(cli_string.split() if cli_string else None))
     return args
 

--- a/xournalpp_htr/xio.py
+++ b/xournalpp_htr/xio.py
@@ -73,7 +73,13 @@ def write_predictions_to_PDF(
             # Place the baseline so characters are vertically centred on the
             # box, and horizontally centre the word within it.
             box_h = prediction.ymax - prediction.ymin
-            fontsize = 6 if small_text else box_h * _fontsize_fill_factor
+            box_w = prediction.xmax - prediction.xmin
+            if small_text:
+                fontsize = 6
+            else:
+                fontsize_from_height = box_h * _fontsize_fill_factor
+                fontsize_from_width = box_w / _helv.text_length(prediction.text, 1.0)
+                fontsize = min(fontsize_from_height, fontsize_from_width)
 
             box_center_y = (prediction.ymin + prediction.ymax) / 2
             baseline_y = box_center_y + _char_center_to_baseline * fontsize

--- a/xournalpp_htr/xio.py
+++ b/xournalpp_htr/xio.py
@@ -28,6 +28,7 @@ def write_predictions_to_PDF(
     output_pdf_file: Path,
     predictions: dict[PageIndex, list[WordPrediction]],
     debug_htr: bool,
+    small_text: bool = False,
 ) -> None:
     """
     Writes handwritten text predictions to a PDF file.
@@ -47,32 +48,46 @@ def write_predictions_to_PDF(
 
     nr_pages = len(doc)
 
+    # Cache font metrics for Helvetica (the default font used by insert_text).
+    _helv = pymupdf.Font("helv")
+    # Scale factor: fills ~95% of the bounding box height with a single text line.
+    _fontsize_fill_factor = 0.95 / (_helv.ascender - _helv.descender)
+    # In PyMuPDF (y-down), char_center_y = baseline_y - ascender*fs + line_h/2
+    # Rearranging: baseline_y = char_center_y + (ascender + descender)/2 * fs
+    _char_center_to_baseline = (_helv.ascender + _helv.descender) / 2
+
     for page_index in tqdm(range(nr_pages), desc="Export to PDF"):
         pdf_page = doc[page_index]
 
         for prediction in predictions[page_index]:
-            if debug_htr:
-                pdf_page.draw_rect(
-                    rect=pymupdf.Rect(
-                        [prediction.xmin, prediction.ymin],
-                        [prediction.xmax, prediction.ymax],
-                    ),
-                    color=pymupdf.pdfcolor["blue"],
-                )
-
-            pdf_page.insert_textbox(
-                rect=pymupdf.Rect(
-                    [prediction.xmin, prediction.ymin],
-                    [prediction.xmax, prediction.ymax],
-                ),
-                buffer=prediction.text,
-                color=pymupdf.pdfcolor["blue"],
-                align=pymupdf.TEXT_ALIGN_CENTER,
-                fontsize=6,
-                render_mode=0 if debug_htr else 3,  # 0 for visible, 3 for invisible
+            rect = pymupdf.Rect(
+                [prediction.xmin, prediction.ymin],
+                [prediction.xmax, prediction.ymax],
             )
-            # TODO: Improve text alignment with prediction. (1) center text vertically and then (2) stretch text to full box.
-            #       Re (1) see https://github.com/pymupdf/PyMuPDF/discussions/1662.
+
+            if debug_htr:
+                pdf_page.draw_rect(rect=rect, color=pymupdf.pdfcolor["blue"])
+
+            # Scale the fontsize to fill the prediction bounding box height so
+            # that text selection in PDF viewers aligns with the handwriting.
+            # Place the baseline so characters are vertically centred on the
+            # box, and horizontally centre the word within it.
+            box_h = prediction.ymax - prediction.ymin
+            fontsize = 6 if small_text else box_h * _fontsize_fill_factor
+
+            box_center_y = (prediction.ymin + prediction.ymax) / 2
+            baseline_y = box_center_y + _char_center_to_baseline * fontsize
+
+            text_width = _helv.text_length(prediction.text, fontsize)
+            x_start = (prediction.xmin + prediction.xmax) / 2 - text_width / 2
+
+            pdf_page.insert_text(
+                point=(x_start, baseline_y),
+                text=prediction.text,
+                fontsize=fontsize,
+                color=pymupdf.pdfcolor["blue"],
+                render_mode=0 if debug_htr else 3,
+            )
 
     doc.ez_save(output_pdf_file)
 

--- a/xournalpp_htr/xio.py
+++ b/xournalpp_htr/xio.py
@@ -60,6 +60,9 @@ def write_predictions_to_PDF(
         pdf_page = doc[page_index]
 
         for prediction in predictions[page_index]:
+            if not prediction.text:
+                continue
+
             rect = pymupdf.Rect(
                 [prediction.xmin, prediction.ymin],
                 [prediction.xmax, prediction.ymax],


### PR DESCRIPTION
Fixes #57.

## Summary

- Replaces `insert_textbox` with `insert_text` using a proportional fontsize so that invisible text in the PDF aligns spatially with the handwriting strokes, making text selection in PDF viewers snap to the correct words
- Fontsize is capped by both box height and box width to prevent text from overflowing the bounding box
- Empty predictions are skipped early to avoid division by zero
- Adds `--small-text` flag to use a fixed 6pt fontsize instead of proportional scaling, useful with `--show-predictions` to reduce visual clutter

## Test plan

- [x] Run without flags and verify text selection aligns with handwriting in a PDF viewer
- [x] Run with `--show-predictions` and verify blue rects and text align with strokes
- [x] Run with `--show-predictions --small-text` and verify smaller, less cluttered overlay
- [x] Existing test suite passes (`make tests-not-slow`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)