### PR TITLE
Remove local-only paths from code and docs (closes #85)

### DIFF
--- a/docs/PoCs/simplify_installation_with_single_file_executable.md
+++ b/docs/PoCs/simplify_installation_with_single_file_executable.md
@@ -36,8 +36,8 @@ pyinstaller --onefile \
     --hidden-import "PIL._tkinter_finder" \
     run_htr.py
 
-dist/run_htr --input-file /home/martin/data/xournalpp_htr/test_1.xoj \
-             --output-file /home/martin/Development/xournalpp_htr/tests/test_1_from_Xpp-3.pdf
+dist/run_htr --input-file /path/to/input.xoj \
+             --output-file /path/to/output.pdf
 ```
 
 ## Results

--- a/plugin/config.lua
+++ b/plugin/config.lua
@@ -1,14 +1,14 @@
 local _M = {}
 
 -- user settings
-_M.python_executable = "/home/martin/Development/xournalpp_htr/.venv/bin/python"
-_M.xournalpp_htr_path = "/home/martin/Development/xournalpp_htr/xournalpp_htr/run_htr.py"
+_M.python_executable = "/path/to/python"
+_M.xournalpp_htr_path = "/path/to/xournalpp_htr/run_htr.py"
 _M.pipeline = "dummy"
-_M.output_file = "/home/martin/Development/xournalpp_htr/tests/test_1_from_Xpp.pdf"
+_M.output_file = "/path/to/output.pdf"
 _M.debug_HTR_command = false
 -- TODO: allow UI to set other parameters as well of `xournalpp_htr`.
 
 -- TODO replace later w/ temp exported file - filename will be derived automatically
-_M.filename = "/home/martin/Development/xournalpp_htr/tests/test_1.xoj"
+_M.filename = "/path/to/input.xoj"
 
 return _M

--- a/plugin/demo_config.lua
+++ b/plugin/demo_config.lua
@@ -1,14 +1,14 @@
 local _M = {}
 
 -- user settings
-_M.python_executable = "/home/martin/anaconda3/envs/xournalpp_htr/bin/python"
-_M.xournalpp_htr_path = "/home/martin/Development/xournalpp_htr/xournalpp_htr/run_htr.py"
+_M.python_executable = "/path/to/python"
+_M.xournalpp_htr_path = "/path/to/xournalpp_htr/run_htr.py"
 _M.pipeline = "dummy"
-_M.output_file = "/home/martin/Development/xournalpp_htr/tests/test_1_from_Xpp.pdf"
+_M.output_file = "/path/to/output.pdf"
 _M.debug_HTR_command = false
 -- TODO: allow UI to set other parameters as well of `xournalpp_htr`.
 
 -- TODO replace later w/ temp exported file - filename will be derived automatically
-_M.filename = "/home/martin/Development/xournalpp_htr/tests/test_1.xoj"
+_M.filename = "/path/to/input.xoj"
 
 return _M

--- a/xournalpp_htr/training/annotate.py
+++ b/xournalpp_htr/training/annotate.py
@@ -1,6 +1,5 @@
 """This script helps to annotate Xournal++ files."""
 
-import argparse
 import dataclasses
 import datetime
 import tkinter as tk
@@ -62,7 +61,7 @@ def draw_document():
     # Plot points
     for layer in xpp_document.pages[I_PAGE].layers:
         for stroke in layer.strokes:
-            for coord_x, coord_y in zip(stroke.x, stroke.y):
+            for coord_x, coord_y in zip(stroke.x, stroke.y, strict=False):
                 draw_a_point(canvas, coord_x, coord_y, color)
 
     if DRAW_STROKE_BOUNDING_BOX.get():
@@ -148,18 +147,13 @@ def update_bbox_text():
 
 
 def export():
-    if DEBUG:
-        output_path = Path(
-            "/home/martin/Development/xournalpp_htr/tests/data/2024-10-13_minimal.annotations.json"
+    output_path = Path(
+        asksaveasfilename(
+            initialfile="Untitled.json",
+            defaultextension=".json",
+            filetypes=[("All Files", "*.*"), ("JSON Documents", "*.json")],
         )
-    else:
-        output_path = Path(
-            asksaveasfilename(
-                initialfile="Untitled.json",
-                defaultextension=".json",
-                filetypes=[("All Files", "*.*"), ("JSON Documents", "*.json")],
-            )
-        )
+    )
 
     xpp_document = XournalppDocument(Path(currently_loaded_document))
 
@@ -225,24 +219,13 @@ def export():
 # =========
 
 
-parser = argparse.ArgumentParser(prog="annotate helper")
-parser.add_argument("-d", "--debug", action="store_true", help="Enable debug mode.")
-args = vars(parser.parse_args())
-
-DEBUG = args["debug"]
-
 root = tk.Tk()  # create root window
 root.title("Annotate Tool")  # title of the GUI window
 root.geometry("1000x800")
 root.config(bg="skyblue")  # specify background color
 
 
-if DEBUG:
-    currently_loaded_document = Path(
-        "/home/martin/Development/xournalpp_htr/tests/data/2024-07-26_minimal.xopp"
-    )
-else:
-    currently_loaded_document = None
+currently_loaded_document = None
 
 
 I_PAGE = 0


### PR DESCRIPTION
## Summary
- Drop hardcoded `/home/martin/...` debug paths in `annotate.py` (along with the now-dead `--debug` argparse plumbing and `argparse` import). Pointed at `tests/data/` files that no longer exist anyway.
- Replace `/home/martin/...` defaults in `plugin/config.lua` and `plugin/demo_config.lua` with `/path/to/...` placeholders so the templates aren't laptop-specific.
- Replace `/home/martin/...` example paths in the single-file-executable PoC doc with the same placeholder style.

Resolves the audit asked for in #85. Prior closed issues #82 (test fixtures) and #17 (plugin install path) covered the rest.

## Test plan
- [x] `make tests-not-slow` — 31 passed, 8 deselected.
- [x] Manual smoke of `annotate.py` (optional; tool is untested per its own TODO comment).