### PR TITLE
Prepare repo for git worktrees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/bootstrap_worktree.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ external/
 tests/data/
 data/datasets/
 .ipynb_checkpoints/
+.claude/worktrees/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/scripts/bootstrap_worktree.sh
+++ b/scripts/bootstrap_worktree.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Bootstrap a linked git worktree by symlinking gitignored files from the
+# main checkout. Idempotent: safe to run on every Claude session start.
+set -euo pipefail
+
+worktree_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$worktree_root"
+
+git_dir=$(git rev-parse --git-dir)
+common_dir=$(git rev-parse --git-common-dir)
+git_dir_abs=$(cd "$git_dir" && pwd)
+common_dir_abs=$(cd "$common_dir" && pwd)
+
+[ "$git_dir_abs" = "$common_dir_abs" ] && exit 0
+
+main_worktree=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
+[ -z "$main_worktree" ] && exit 0
+[ "$main_worktree" = "$worktree_root" ] && exit 0
+
+if [ ! -e ".env" ] && [ -e "$main_worktree/.env" ]; then
+    ln -s "$main_worktree/.env" ".env"
+    echo "bootstrap_worktree: linked .env from $main_worktree"
+fi


### PR DESCRIPTION
## Summary
- Ignore `.claude/worktrees/` so per-developer worktree checkouts created by `claude -w` are not tracked.
- Add `scripts/bootstrap_worktree.sh` that symlinks `.env` from the main checkout into a linked worktree if missing (idempotent; no-op in the main checkout).
- Wire it up via a `SessionStart` hook in `.claude/settings.json` so it runs automatically each time a session starts in a worktree.

Closes #109.

## Test plan
- [ ] In a fresh `claude -w some-branch` session, confirm `.env` appears as a symlink to the main checkout.
- [ ] Re-running in the same worktree leaves `.env` untouched (idempotent).
- [ ] In the main checkout, the hook is a silent no-op.