### PR TITLE
Design a consistent issue labeling system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,4 @@
 ## Issue-Driven Workflow
 
 - Default workflow: issue → branch (`gh issue develop <number>`) → PR referencing the issue (also using `gh`).
+- When creating an issue with `gh`, apply labels from the taxonomy in [`docs/labels.md`](docs/labels.md): at least one **type** (`bug`, `enhancement`, `refactor`, `research`, `documentation`, `question`) and, when scoped to a part of the project, one or more **area** labels (`pipeline`, `training`, `models`, `plugin`, `installation`, `devex`, `ci-cd`, `architecture`). Keep the set minimal — usually one type + one area.

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -1,0 +1,54 @@
+# Issue Labels
+
+This page defines the labeling taxonomy used in this repository. Apply at
+least one **type** label to every issue, and one or more **area** labels
+when the issue is scoped to a specific part of the project. **Meta** labels
+are optional and signal triage state.
+
+Aim for the minimum set that accurately describes the issue — typically one
+type + one area.
+
+## Type — what kind of work
+
+| Label           | When to use                                                                                |
+| --------------- | ------------------------------------------------------------------------------------------ |
+| `bug`           | Something is broken or behaves incorrectly.                                                |
+| `enhancement`   | New feature or improvement to existing behavior.                                           |
+| `refactor`      | Code restructuring without changing behavior.                                              |
+| `research`      | Exploratory work: spikes, evaluations, brainstorms, "try out X".                           |
+| `documentation` | Changes scoped to docs, READMEs, ADRs, or in-code documentation.                           |
+| `question`      | Open question or discussion — no defined deliverable yet.                                  |
+
+## Area — where in the project
+
+| Label          | When to use                                                                                |
+| -------------- | ------------------------------------------------------------------------------------------ |
+| `pipeline`     | HTR inference pipeline / runtime (`run_htr.py`, `inference_models.py`, etc.).              |
+| `training`     | Model training loops, training data handling, training-time evaluation.                    |
+| `models`       | Model architectures and the model registry.                                                |
+| `plugin`       | Xournal++ Lua plugin and editor integration.                                               |
+| `installation` | Installation, packaging, install scripts, PyInstaller, install modes.                      |
+| `devex`        | Developer experience: CLI shape, type-checking, harness, agentic tooling.                  |
+| `ci-cd`        | CI workflows, release automation, versioning.                                              |
+| `architecture` | Cross-cutting architectural decisions that don't fit a single area.                        |
+
+If an issue genuinely spans multiple areas, apply multiple area labels —
+but prefer the most specific one when possible.
+
+## Meta
+
+| Label              | When to use                                            |
+| ------------------ | ------------------------------------------------------ |
+| `good first issue` | Well-scoped and approachable for a new contributor.    |
+| `help wanted`      | Maintainers would welcome outside help on this issue.  |
+| `duplicate`        | Tracks the same work as another issue.                 |
+| `invalid`          | Not actionable as filed.                               |
+| `wontfix`          | Acknowledged but intentionally not being addressed.    |
+
+## Examples
+
+- "Profile word detector training loop" → `research` + `training`
+- "Fails to OCR with openDialog Lua error" → `bug` + `plugin`
+- "Add CalVer versioning and automated release workflow" → `enhancement` + `ci-cd`
+- "Decide on CLI shape: single entry point vs multiple commands" → `architecture` + `devex`
+- "Add file logging to Lua plugin for easier debugging" → `enhancement` + `plugin` + `good first issue`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
     - Overview: 'models/index.md'
     - WordDetector: 'models/word_detector.md'
   - Contributing: 'contributing.md'
+  - Issue Labels: 'labels.md'
   - Roadmap: 'roadmap.md'
   - Funding: 'funding.md'
 


### PR DESCRIPTION
Closes #107.

## Summary
- Define a small label taxonomy: **type** (`bug`, `enhancement`, `refactor`, `research`, `documentation`, `question`), **area** (`pipeline`, `training`, `models`, `plugin`, `installation`, `devex`, `ci-cd`, `architecture`), and the existing **meta** labels (`good first issue`, `help wanted`, etc.).
- Document it in [`docs/labels.md`](../blob/107-design-a-consistent-issue-labeling-system/docs/labels.md), wired into the mkdocs nav.
- Add a one-line pointer in AGENTS.md (CLAUDE.md is a symlink to it) so Claude Code applies labels at issue creation time.

## Label changes on GitHub
- Created: `research`, `refactor`, `pipeline`, `training`, `models`, `plugin`, `devex`, `ci-cd`.
- Updated descriptions on existing `installation` and `architecture`.
- Deleted `proof-of-concept` and `onboarding` (subsumed by `research` and `documentation` + `good first issue`).

## Retroactive labeling
All 27 open issues now carry at least one type label and (where scoped) one area label. Multi-area issues kept to the most distinctive area to avoid noise.

## Test plan
- [ ] `mkdocs build` succeeds with the new nav entry.
- [ ] Spot-check labels on a few open issues match the taxonomy in `docs/labels.md`.