### PR TITLE
Document experiment2/3 results, add experiment3 script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ tests/data/
 data/datasets/
 .ipynb_checkpoints/
 .claude/worktrees/
+.claude/handover.md
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,6 @@ best_model.pth
 .DS_Store
 
 xournalpp_htr/training/word_detector/experiments
+
+dataset_cache.pickle
+xournalpp_htr/training/word_detector/outputs/

--- a/docs/models/word_detector.md
+++ b/docs/models/word_detector.md
@@ -246,6 +246,38 @@ Suggested entry template:
 
 <!-- Add new experiments below, newest first. -->
 
+### 2026-06-01 — Experiment 3: augmentation under original training regime
+
+- **Goal:** does augmentation help when training closer to the original
+  WordDetectorNN regime (bs=10, unbounded epochs with early stopping)?
+  Experiment 2 showed augmentation hurting under our regime (bs=32,
+  epoch_max=100), but the original repo always uses augmentation with a
+  much smaller batch size and no epoch cap.
+- **Setup:** IAM-DB, 80/20 random split, lr=0.001, bs=10, epoch_max=10000
+  (effectively unbounded, relies on patience_max=50), input 448x448.
+  Augmentation on vs off, 3 seeds each (42, 43, 44). Code revision
+  `948f48f`.
+- **Command:** `bash run_training.sh` (experiment3 function).
+- **Results:**
+
+  | Augmentation | Seed 42 | Seed 43 | Seed 44 | Mean F1 |
+  |---|---|---|---|---|
+  | Off | 0.8750 | 0.8786 | 0.8799 | **0.8779** |
+  | On | 0.8896 | 0.8819 | 0.8787 | **0.8834** |
+
+  Augmented runs trained longer before early stopping (139–416 epochs vs
+  95–165 epochs), indicating augmentation adds useful diversity the model
+  can exploit given enough training time.
+
+  Artefacts: `experiments/experiment3/aug{true,false}_seed{42,43,44}/`.
+
+- **Conclusion:** under the original-like regime (bs=10, unbounded epochs),
+  augmentation helps (+0.55 pp mean F1). Both conditions also outperform
+  experiment 2 overall (mean F1 ~0.88 vs ~0.86), confirming that the
+  smaller batch size with longer training is beneficial. The recommended
+  final training configuration is **bs=10, augmentation on, unbounded
+  epochs with early stopping (patience 50)**.
+
 ### 2026-05-28 — Experiment 2: augmentation ablation
 
 - **Goal:** does train-time data augmentation improve word detector performance?

--- a/docs/models/word_detector.md
+++ b/docs/models/word_detector.md
@@ -246,6 +246,30 @@ Suggested entry template:
 
 <!-- Add new experiments below, newest first. -->
 
+### 2026-05-28 — Experiment 2: augmentation ablation
+
+- **Goal:** does train-time data augmentation improve word detector performance?
+- **Setup:** IAM-DB, 80/20 random split, lr=0.001, bs=32, epoch_max=100,
+  patience_max=50, input 448x448. Augmentation on vs off, 3 seeds each
+  (42, 43, 44). Code revision `58a26e4`.
+- **Command:** `bash run_training.sh` (experiment2 function).
+- **Results:**
+
+  | Augmentation | Seed 42 | Seed 43 | Seed 44 | Mean F1 |
+  |---|---|---|---|---|
+  | Off | 0.8596 | 0.8681 | 0.8590 | **0.8622** |
+  | On | 0.8571 | 0.8574 | 0.8609 | **0.8584** |
+
+  Artefacts: `experiments/experiment2/aug{true,false}_seed{42,43,44}/`.
+
+- **Conclusion:** augmentation slightly hurts performance (~0.4 pp lower
+  mean F1). However, our training regime differs from the
+  [original WordDetectorNN](https://github.com/githubharald/WordDetectorNN)
+  (bs=10, unbounded epochs with early stopping, first-20-sample val split,
+  350x350 input). Experiment 3 will test augmentation under an
+  original-like regime (bs=10, unbounded epochs) to see if augmentation
+  helps there.
+
 ## Current status
 
 Everything from the original WordDetectorNN model is reimplemented, including

--- a/xournalpp_htr/training/word_detector/run_training.sh
+++ b/xournalpp_htr/training/word_detector/run_training.sh
@@ -104,9 +104,9 @@ experiment3() {
 # Run experiments
 # ==================
 
-# experiment1
-# experiment2
-experiment3
+# time experiment1
+# time experiment2
+time experiment3
 
 # ==================
 # Future experiments

--- a/xournalpp_htr/training/word_detector/run_training.sh
+++ b/xournalpp_htr/training/word_detector/run_training.sh
@@ -68,12 +68,45 @@ experiment2() {
     done
 }
 
+# ============
+# Experiment 3
+# ============
+
+# Question: Does augmentation help under the original WordDetectorNN training
+# regime (bs=10, unbounded epochs with early stopping)?
+
+experiment3() {
+    local EPOCH_MAX=10000
+    local BATCH_SIZE=10
+
+    for AUGMENT in false true
+    do
+        for SEED_SPLIT in 42 43 44
+        do
+
+            echo "AUGMENT=${AUGMENT}, SEED=${SEED_SPLIT}"
+
+            OUT="${BASE_PATH}/experiment3/aug${AUGMENT}_seed${SEED_SPLIT}"
+            mkdir -p "${OUT}"
+
+            uv run python -m xournalpp_htr.training.word_detector.train \
+                augmentation.enabled="${AUGMENT}" \
+                seed.split="${SEED_SPLIT}" \
+                training.epoch_max="${EPOCH_MAX}" \
+                training.batch_size="${BATCH_SIZE}" \
+                output_path="${OUT}" 2>&1 | tee "${OUT}/train.log"
+
+        done
+    done
+}
+
 # ==================
 # Run experiments
 # ==================
 
-experiment1
-experiment2
+# experiment1
+# experiment2
+experiment3
 
 # ==================
 # Future experiments


### PR DESCRIPTION
## Summary

- Document experiment2 results (augmentation ablation, bs=32, 100 epochs) in word detector docs
- Add experiment3 script to `run_training.sh`: tests augmentation under the original WordDetectorNN regime (bs=10, unbounded epochs with early stopping)
- Document experiment3 results: augmentation helps under the original regime (+0.55 pp mean F1), recommended final config is bs=10, augmentation on, unbounded epochs with patience 50
- Ignore `dataset_cache.pickle` and `xournalpp_htr/training/word_detector/outputs/` in `.gitignore`

## Test plan

- [ ] Verify experiment log entries render correctly in docs
- [ ] Verify `run_training.sh` experiment3 function has correct Hydra overrides

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)