### PR TITLE
Implement SimpleHTR model (CNN+BiLSTM+CTC)

### DIFF
--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -7,6 +7,9 @@ model.
 - [WordDetector](word_detector.md) — word-level bounding-box detector
   (reimplementation of
   [WordDetectorNN](https://github.com/githubharald/WordDetectorNN)).
+- [SimpleHTR](simple_htr.md) — word-level text recognition
+  (reimplementation of
+  [SimpleHTR](https://github.com/githubharald/SimpleHTR)).
 
 New models added in the future should follow the same structure: a page under
 `docs/models/<model_name>.md` linked from this index and from the `Models`

--- a/docs/models/simple_htr.md
+++ b/docs/models/simple_htr.md
@@ -1,0 +1,145 @@
+# SimpleHTR
+
+Handwritten word recognition model — reimplementation of
+[Harald Scheidl's SimpleHTR](https://github.com/githubharald/SimpleHTR).
+Architecture: 5 CNN layers + 2 bidirectional LSTM layers + CTC output.
+Takes a single word image and predicts the text.
+
+Source: `xournalpp_htr/training/simple_htr/`
+
+## File structure
+
+| File | Purpose | Deps |
+|------|---------|------|
+| `config.py` | Hydra structured config | base |
+| `network.py` | `SimpleHTRNet` (CNN+BiLSTM+CTC) | training |
+| `dataset.py` | IAM word-level dataset loader | training |
+| `train.py` | Training entrypoint (`@hydra.main`) | training |
+| `infer.py` | Local torch inference from `.pth` | training |
+| `demo.py` | Local Gradio demo (ADR 007) | training |
+| `export.py` | ONNX export + HF Hub upload | training |
+| `utils.py` | Device, git hash, JSON encoder | training |
+| `run_training.sh` | Hyperparameter sweep script | shell |
+
+## GPU training setup
+
+### 1. Clone and install base
+
+```bash
+git clone https://github.com/PellelNitram/xournalpp_htr.git
+cd xournalpp_htr
+bash INSTALL_LINUX.sh
+```
+
+### 2. Install training extra with CUDA PyTorch
+
+```bash
+uv sync --extra training-simple-htr
+```
+
+### 3. Verify GPU
+
+```bash
+uv run python -c "import torch; print(torch.cuda.is_available())"
+```
+
+### 4. Authenticate with HuggingFace
+
+```bash
+uv run huggingface-cli login
+```
+
+### 5. Download dataset
+
+The IAM-DB dataset is downloaded automatically on first training run.
+It includes pre-cropped word images (`data/words/`) and ground truth
+(`data/ascii/words.txt`).
+
+## Training
+
+### Single run
+
+```bash
+uv run python -m xournalpp_htr.training.simple_htr.train \
+    training.learning_rate=0.001 \
+    training.batch_size=64 \
+    training.epoch_max=100 \
+    output_path=outputs
+```
+
+### Hyperparameter sweep
+
+```bash
+bash xournalpp_htr/training/simple_htr/run_training.sh
+```
+
+## Evaluation
+
+Find the best model from a sweep:
+
+```bash
+find experiments/ -name "best_model.json" -exec sh -c \
+    'echo "--- $1 ---"; cat "$1"' _ {} \;
+```
+
+## Inspection
+
+### Gradio demo
+
+```bash
+uv run python -m xournalpp_htr.training.simple_htr.demo \
+    --model-path <path>/best_model.pth --device auto
+```
+
+## Export
+
+### ONNX export
+
+```bash
+uv run python -m xournalpp_htr.training.simple_htr.export \
+    --checkpoint <path>/best_model.pth --output-dir exports/
+```
+
+### Validate ONNX
+
+Use the `test_best_model.ipynb` notebook to compare PyTorch and ONNX outputs.
+
+### Upload to HF Hub
+
+```bash
+uv run python -m xournalpp_htr.training.simple_htr.export \
+    --checkpoint <path>/best_model.pth --output-dir exports/ --upload
+```
+
+## Inference
+
+```python
+from xournalpp_htr.inference_models import SimpleHTRModel
+
+model = SimpleHTRModel.from_pretrained()
+text = model.recognize(word_image_grayscale)
+print(text)
+```
+
+## Experiments
+
+_No experiments logged yet._
+
+## Current status
+
+- [x] Network architecture (CNN + BiLSTM + CTC)
+- [x] IAM word-level dataset loader with caching
+- [x] Training loop with CER/word accuracy validation
+- [x] ONNX export and HF Hub upload
+- [x] Inference model (`SimpleHTRModel`)
+- [x] Local Gradio demo
+- [x] Hyperparameter sweep script
+- [ ] First training run and experiment log
+- [ ] ONNX validation notebook
+
+## Outlook
+
+- Run experiment 1 (LR/BS sweep) and document results
+- Add augmentation experiment
+- Add beam search decoding
+- Integrate into full pipeline (word detection + recognition)

--- a/docs/models/simple_htr.md
+++ b/docs/models/simple_htr.md
@@ -19,6 +19,7 @@ Source: `xournalpp_htr/training/simple_htr/`
 | `demo.py` | Local Gradio demo (ADR 007) | training |
 | `export.py` | ONNX export + HF Hub upload | training |
 | `utils.py` | Device, git hash, JSON encoder | training |
+| `test_best_model.ipynb` | ONNX validation notebook | training |
 | `run_training.sh` | Hyperparameter sweep script | shell |
 
 ## GPU training setup
@@ -211,7 +212,7 @@ print(text)
 - [x] Local Gradio demo
 - [x] Hyperparameter sweep script
 - [x] First training run and experiment log
-- [ ] ONNX validation notebook
+- [x] ONNX validation notebook
 
 ## Outlook
 

--- a/docs/models/simple_htr.md
+++ b/docs/models/simple_htr.md
@@ -123,35 +123,33 @@ print(text)
 
 ## Experiments
 
-### 2026-06-02 — Experiment 1: learning rate and batch size sweep
+### 2026-06-03 — Experiment 1: learning rate and batch size sweep
 
 - **Hypothesis:** Find the best learning rate and batch size combination
   for the default SimpleHTR architecture on IAM words.
 - **Setup:** IAM word-level dataset, 95/5 train/val split, no augmentation,
-  early stopping with patience 15, max 100 epochs. Grid: LR ∈ {0.0005,
+  early stopping with patience 25, max 100 epochs. Grid: LR ∈ {0.0005,
   0.001, 0.002} × BS ∈ {32, 64, 128}. NVIDIA A100 40GB.
 - **Command:** `bash xournalpp_htr/training/simple_htr/run_training.sh`
-- **Code revision:** `a72b64c`
+- **Code revision:** `89971fe`
 - **Results:**
 
 | LR | BS | Best Epoch | CER | Word Acc | Path |
 |---|---|---|---|---|---|
-| 0.001 | 64 | 64 | **0.072** | **78.9%** | `experiments/experiment1/lr0.001_bs64/` |
-| 0.0005 | 32 | 15 | 0.075 | 78.1% | `experiments/experiment1/lr0.0005_bs32/` |
-| 0.0005 | 64 | 28 | 0.076 | 77.1% | `experiments/experiment1/lr0.0005_bs64/` |
-| 0.001 | 32 | 37 | 0.078 | 77.4% | `experiments/experiment1/lr0.001_bs32/` |
-| 0.001 | 128 | 29 | 0.078 | 77.7% | `experiments/experiment1/lr0.001_bs128/` |
-| 0.0005 | 128 | 20 | 0.078 | 77.2% | `experiments/experiment1/lr0.0005_bs128/` |
-| 0.002 | 128 | 41 | 0.078 | 77.1% | `experiments/experiment1/lr0.002_bs128/` |
-| 0.002 | 64 | 32 | 0.080 | 76.4% | `experiments/experiment1/lr0.002_bs64/` |
-| 0.002 | 32 | 44 | 0.081 | 76.3% | `experiments/experiment1/lr0.002_bs32/` |
+| 0.0005 | 64 | 54 | **0.070** | **79.2%** | `experiments/experiment1/lr0.0005_bs64/` |
+| 0.0005 | 32 | 27 | 0.070 | 79.3% | `experiments/experiment1/lr0.0005_bs32/` |
+| 0.0005 | 128 | 83 | 0.073 | 78.8% | `experiments/experiment1/lr0.0005_bs128/` |
+| 0.001 | 64 | 33 | 0.074 | 78.8% | `experiments/experiment1/lr0.001_bs64/` |
+| 0.001 | 128 | 41 | 0.074 | 77.8% | `experiments/experiment1/lr0.001_bs128/` |
+| 0.002 | 128 | 56 | 0.075 | 77.8% | `experiments/experiment1/lr0.002_bs128/` |
+| 0.001 | 32 | 59 | 0.076 | 77.3% | `experiments/experiment1/lr0.001_bs32/` |
+| 0.002 | 32 | 20 | 0.086 | 74.9% | `experiments/experiment1/lr0.002_bs32/` |
+| 0.002 | 64 | 29 | 0.089 | 75.1% | `experiments/experiment1/lr0.002_bs64/` |
 
-- **Conclusion:** LR=0.001 with BS=64 achieves the best CER (0.072) and
-  word accuracy (78.9%), matching the original SimpleHTR's reported ~75%.
-  Performance is fairly stable across configurations (CER 0.072–0.081).
-  Lower learning rates (0.0005) converge in fewer epochs but reach similar
-  accuracy; higher LR (0.002) slightly underperforms. Recommended defaults:
-  LR=0.001, BS=64.
+- **Conclusion:** LR=0.0005 with BS=64 achieves the best CER (0.070) and
+  word accuracy (79.2%). The top-3 configs all use LR=0.0005, showing that
+  lower learning rates consistently outperform. LR=0.002 clearly
+  underperforms. Recommended defaults: LR=0.0005, BS=64.
 
 ## Current status
 

--- a/docs/models/simple_htr.md
+++ b/docs/models/simple_htr.md
@@ -151,6 +151,56 @@ print(text)
   lower learning rates consistently outperform. LR=0.002 clearly
   underperforms. Recommended defaults: LR=0.0005, BS=64.
 
+### 2026-06-05 — Experiment 2: augmentation
+
+- **Hypothesis:** Data augmentation (Gaussian blur, geometric transforms,
+  morphological ops, contrast/noise) improves generalisation.
+- **Setup:** LR=0.0005 (best from exp1), BS ∈ {32, 64, 128} ×
+  augmentation {on, off}. Max 200 epochs, patience 25. NVIDIA A100 40GB.
+- **Command:** `bash xournalpp_htr/training/simple_htr/run_training.sh`
+- **Code revision:** `f5f8c60`
+- **Results:**
+
+| Aug | BS | Best Epoch | CER | Word Acc | Path |
+|---|---|---|---|---|---|
+| true | 128 | 142 | **0.060** | **82.9%** | `experiments/experiment2/augtrue_bs128/` |
+| true | 32 | 91 | 0.061 | 82.7% | `experiments/experiment2/augtrue_bs32/` |
+| true | 64 | 62 | 0.062 | 81.8% | `experiments/experiment2/augtrue_bs64/` |
+| false | 32 | 27 | 0.070 | 79.3% | `experiments/experiment2/augfalse_bs32/` |
+| false | 64 | 54 | 0.070 | 79.2% | `experiments/experiment2/augfalse_bs64/` |
+| false | 128 | 83 | 0.073 | 78.8% | `experiments/experiment2/augfalse_bs128/` |
+
+- **Conclusion:** Augmentation consistently improves results across all
+  batch sizes, reducing CER from ~0.070 to ~0.060 and lifting word accuracy
+  from ~79% to ~83%. Augmented runs need more epochs to converge (62–142
+  vs 27–83). Batch size has minimal effect with augmentation enabled.
+
+### 2026-06-05 — Experiment 3: dropout
+
+- **Hypothesis:** Dropout between RNN layers provides additional
+  regularisation, especially when combined with augmentation.
+- **Setup:** LR=0.0005, BS=64. Dropout ∈ {0.0, 0.2, 0.5} ×
+  augmentation {on, off}. Max 200 epochs, patience 25. NVIDIA A100 40GB.
+- **Command:** `bash xournalpp_htr/training/simple_htr/run_training.sh`
+- **Code revision:** `f5f8c60`
+- **Results:**
+
+| Dropout | Aug | Best Epoch | CER | Word Acc | Path |
+|---|---|---|---|---|---|
+| 0.5 | true | 67 | **0.056** | **84.2%** | `experiments/experiment3/do0.5_augtrue/` |
+| 0.2 | true | 79 | 0.058 | 83.2% | `experiments/experiment3/do0.2_augtrue/` |
+| 0.0 | true | 62 | 0.062 | 81.8% | `experiments/experiment3/do0.0_augtrue/` |
+| 0.5 | false | 64 | 0.067 | 80.4% | `experiments/experiment3/do0.5_augfalse/` |
+| 0.2 | false | 22 | 0.070 | 78.8% | `experiments/experiment3/do0.2_augfalse/` |
+| 0.0 | false | 54 | 0.070 | 79.2% | `experiments/experiment3/do0.0_augfalse/` |
+
+- **Conclusion:** Dropout and augmentation are complementary. The best
+  config (dropout=0.5, augmentation on) achieves CER 0.056 and 84.2% word
+  accuracy — a major improvement over the experiment 1 baseline (CER 0.070,
+  79.2%). Higher dropout consistently helps; the effect is strongest when
+  combined with augmentation. Recommended defaults: dropout=0.5,
+  augmentation enabled.
+
 ## Current status
 
 - [x] Network architecture (CNN + BiLSTM + CTC)
@@ -165,6 +215,5 @@ print(text)
 
 ## Outlook
 
-- Add augmentation experiment
-- Add beam search decoding
+- Add beam search decoding (issue #120)
 - Integrate into full pipeline (word detection + recognition)

--- a/docs/models/simple_htr.md
+++ b/docs/models/simple_htr.md
@@ -123,7 +123,35 @@ print(text)
 
 ## Experiments
 
-_No experiments logged yet._
+### 2026-06-02 — Experiment 1: learning rate and batch size sweep
+
+- **Hypothesis:** Find the best learning rate and batch size combination
+  for the default SimpleHTR architecture on IAM words.
+- **Setup:** IAM word-level dataset, 95/5 train/val split, no augmentation,
+  early stopping with patience 15, max 100 epochs. Grid: LR ∈ {0.0005,
+  0.001, 0.002} × BS ∈ {32, 64, 128}. NVIDIA A100 40GB.
+- **Command:** `bash xournalpp_htr/training/simple_htr/run_training.sh`
+- **Code revision:** `a72b64c`
+- **Results:**
+
+| LR | BS | Best Epoch | CER | Word Acc | Path |
+|---|---|---|---|---|---|
+| 0.001 | 64 | 64 | **0.072** | **78.9%** | `experiments/experiment1/lr0.001_bs64/` |
+| 0.0005 | 32 | 15 | 0.075 | 78.1% | `experiments/experiment1/lr0.0005_bs32/` |
+| 0.0005 | 64 | 28 | 0.076 | 77.1% | `experiments/experiment1/lr0.0005_bs64/` |
+| 0.001 | 32 | 37 | 0.078 | 77.4% | `experiments/experiment1/lr0.001_bs32/` |
+| 0.001 | 128 | 29 | 0.078 | 77.7% | `experiments/experiment1/lr0.001_bs128/` |
+| 0.0005 | 128 | 20 | 0.078 | 77.2% | `experiments/experiment1/lr0.0005_bs128/` |
+| 0.002 | 128 | 41 | 0.078 | 77.1% | `experiments/experiment1/lr0.002_bs128/` |
+| 0.002 | 64 | 32 | 0.080 | 76.4% | `experiments/experiment1/lr0.002_bs64/` |
+| 0.002 | 32 | 44 | 0.081 | 76.3% | `experiments/experiment1/lr0.002_bs32/` |
+
+- **Conclusion:** LR=0.001 with BS=64 achieves the best CER (0.072) and
+  word accuracy (78.9%), matching the original SimpleHTR's reported ~75%.
+  Performance is fairly stable across configurations (CER 0.072–0.081).
+  Lower learning rates (0.0005) converge in fewer epochs but reach similar
+  accuracy; higher LR (0.002) slightly underperforms. Recommended defaults:
+  LR=0.001, BS=64.
 
 ## Current status
 
@@ -134,12 +162,11 @@ _No experiments logged yet._
 - [x] Inference model (`SimpleHTRModel`)
 - [x] Local Gradio demo
 - [x] Hyperparameter sweep script
-- [ ] First training run and experiment log
+- [x] First training run and experiment log
 - [ ] ONNX validation notebook
 
 ## Outlook
 
-- Run experiment 1 (LR/BS sweep) and document results
 - Add augmentation experiment
 - Add beam search decoding
 - Integrate into full pipeline (word detection + recognition)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,14 @@ training-word-detector = [
     "gradio",  # local demo (ADR 007); run locally, not as a HF Space
     "hydra-core",
 ]
+training-simple-htr = [
+    "torch",
+    "torchvision",
+    "tensorboard",
+    "onnx",
+    "gradio",
+    "hydra-core",
+]
 dev = [
     "jupyter",
 ]

--- a/tests/test_inference_models.py
+++ b/tests/test_inference_models.py
@@ -7,7 +7,11 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from xournalpp_htr.inference_models import HFHubInferenceModel, WordDetectorModel
+from xournalpp_htr.inference_models import (
+    HFHubInferenceModel,
+    SimpleHTRModel,
+    WordDetectorModel,
+)
 from xournalpp_htr.training.shared.bounding_box import BoundingBox
 
 CHECKPOINT = (
@@ -15,6 +19,14 @@ CHECKPOINT = (
     / "xournalpp_htr"
     / "training"
     / "word_detector"
+    / "best_model.pth"
+)
+
+SIMPLE_HTR_CHECKPOINT = (
+    Path(__file__).parents[1]
+    / "xournalpp_htr"
+    / "training"
+    / "simple_htr"
     / "best_model.pth"
 )
 
@@ -55,6 +67,13 @@ def test_word_detector_repo_id_follows_adr006_naming():
     assert WordDetectorModel.HF_REPO_ID == "PellelNitram/xournalpp-htr-word-detector"
     assert re.fullmatch(
         r"PellelNitram/xournalpp-htr-[a-z0-9-]+", WordDetectorModel.HF_REPO_ID
+    )
+
+
+def test_simple_htr_repo_id_follows_adr006_naming():
+    assert SimpleHTRModel.HF_REPO_ID == "PellelNitram/xournalpp-htr-simple-htr"
+    assert re.fullmatch(
+        r"PellelNitram/xournalpp-htr-[a-z0-9-]+", SimpleHTRModel.HF_REPO_ID
     )
 
 
@@ -103,3 +122,38 @@ def test_word_detector_onnx_roundtrip_offline(tmp_path: Path):
         assert np.isfinite([b.x_min, b.y_min, b.x_max, b.y_max]).all()
         assert -1 <= b.x_min and b.x_max <= w + 1
         assert -1 <= b.y_min and b.y_max <= h + 1
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not SIMPLE_HTR_CHECKPOINT.exists(),
+    reason="best_model.pth is gitignored / local-only; skip ONNX round-trip in CI",
+)
+def test_simple_htr_onnx_roundtrip_offline(tmp_path: Path):
+    import onnxruntime as ort
+
+    pytest.importorskip(
+        "tensorboard",
+        reason="needs the training-simple-htr extra to export the checkpoint",
+    )
+    from xournalpp_htr.training.simple_htr.export import export
+
+    paths = export(SIMPLE_HTR_CHECKPOINT, tmp_path)
+    assert paths["onnx"].exists() and paths["config"].exists()
+
+    with open(paths["config"]) as f:
+        config = json.load(f)
+
+    model = SimpleHTRModel(
+        session=ort.InferenceSession(str(paths["onnx"])),
+        config=config,
+        revision="local",
+    )
+    assert "simple-htr" in repr(model)
+
+    h, w = 32, 100
+    rng = np.random.default_rng(0)
+    img = rng.integers(0, 255, size=(h, w), dtype=np.uint8)
+
+    text = model.recognize(img)
+    assert isinstance(text, str)

--- a/xournalpp_htr/inference_models.py
+++ b/xournalpp_htr/inference_models.py
@@ -155,21 +155,24 @@ class SimpleHTRModel(HFHubInferenceModel):
         """Recognise text in a grayscale word image.
 
         The image is resized to the network's expected input dimensions
-        (height-preserving with padding) and normalised before inference.
+        (uniform scale, centered on white canvas) and normalised before inference.
         """
         input_size = self.config["input_size"]
         in_h, in_w = input_size["height"], input_size["width"]
         norm = self.config["normalization"]
 
         h, w = image_grayscale.shape[:2]
-        scale = in_h / h
-        new_w = min(int(w * scale), in_w)
-        resized = cv2.resize(image_grayscale, (new_w, in_h))
+        scale = min(in_w / w, in_h / h)
+        new_w = int(w * scale)
+        new_h = int(h * scale)
+        resized = cv2.resize(image_grayscale, (new_w, new_h))
 
-        padded = np.ones((in_h, in_w), dtype=np.uint8) * 255
-        padded[:, :new_w] = resized
+        canvas = np.ones((in_h, in_w), dtype=np.uint8) * 255
+        y_off = (in_h - new_h) // 2
+        x_off = (in_w - new_w) // 2
+        canvas[y_off : y_off + new_h, x_off : x_off + new_w] = resized
 
-        normalised = padded.astype(np.float32) / norm["scale"] + norm["shift"]
+        normalised = canvas.astype(np.float32) / norm["scale"] + norm["shift"]
         net_input = normalised[None, None, :, :]
 
         log_probs = self.session.run(None, {self._input_name: net_input})[0]

--- a/xournalpp_htr/inference_models.py
+++ b/xournalpp_htr/inference_models.py
@@ -120,3 +120,67 @@ class WordDetectorModel(HFHubInferenceModel):
         # Map from the fixed network input space back to the passed image.
         sx, sy = orig_w / in_w, orig_h / in_h
         return [aabb.scale(sx, sy) for aabb in clustered]
+
+
+class SimpleHTRModel(HFHubInferenceModel):
+    """SimpleHTR word-recognition model, loaded from HF Hub as ONNX.
+
+    The repository contains ``model.onnx`` (the CNN+LSTM+CTC network) and
+    ``config.json`` (charset, input dimensions, normalisation). Inference runs
+    the ONNX graph with ``onnxruntime`` and decodes the CTC output into text.
+    """
+
+    HF_REPO_ID = "PellelNitram/xournalpp-htr-simple-htr"
+
+    def __init__(self, session: ort.InferenceSession, config: dict, revision: str):
+        super().__init__(revision)
+        self.session = session
+        self.config = config
+        self._input_name = session.get_inputs()[0].name
+        self._charset = config["charset"]
+
+    @classmethod
+    def from_pretrained(cls, revision: str = "main") -> "SimpleHTRModel":
+        onnx_path = hf_hub_download(cls.HF_REPO_ID, "model.onnx", revision=revision)
+        config_path = hf_hub_download(cls.HF_REPO_ID, "config.json", revision=revision)
+        with open(config_path) as f:
+            config = json.load(f)
+        return cls(
+            session=ort.InferenceSession(onnx_path),
+            config=config,
+            revision=revision,
+        )
+
+    def recognize(self, image_grayscale: np.ndarray) -> str:
+        """Recognise text in a grayscale word image.
+
+        The image is resized to the network's expected input dimensions
+        (height-preserving with padding) and normalised before inference.
+        """
+        input_size = self.config["input_size"]
+        in_h, in_w = input_size["height"], input_size["width"]
+        norm = self.config["normalization"]
+
+        h, w = image_grayscale.shape[:2]
+        scale = in_h / h
+        new_w = min(int(w * scale), in_w)
+        resized = cv2.resize(image_grayscale, (new_w, in_h))
+
+        padded = np.ones((in_h, in_w), dtype=np.uint8) * 255
+        padded[:, :new_w] = resized
+
+        normalised = padded.astype(np.float32) / norm["scale"] + norm["shift"]
+        net_input = normalised[None, None, :, :]
+
+        log_probs = self.session.run(None, {self._input_name: net_input})[0]
+        # log_probs shape: (seq_len, batch, num_classes)
+        predictions = log_probs[:, 0, :].argmax(axis=1)
+
+        blank = len(self._charset)
+        chars = []
+        prev = blank
+        for idx in predictions:
+            if idx != prev and idx != blank:
+                chars.append(self._charset[idx])
+            prev = idx
+        return "".join(chars)

--- a/xournalpp_htr/training/simple_htr/README.md
+++ b/xournalpp_htr/training/simple_htr/README.md
@@ -1,0 +1,5 @@
+# SimpleHTR
+
+Handwritten word recognition model (CNN + BiLSTM + CTC).
+
+See the full documentation at [`docs/models/simple_htr.md`](../../../docs/models/simple_htr.md).

--- a/xournalpp_htr/training/simple_htr/__init__.py
+++ b/xournalpp_htr/training/simple_htr/__init__.py
@@ -1,0 +1,15 @@
+"""SimpleHTR training subpackage (ADR 006 section 3).
+
+Training code for the SimpleHTR text recognition model. Its dependencies are
+declared as the ``training-simple-htr`` optional extra. Inference does *not*
+import this subpackage -- it uses the ONNX export via
+:class:`xournalpp_htr.inference_models.SimpleHTRModel`.
+"""
+
+try:
+    import tensorboard  # noqa: F401
+except ImportError as e:
+    raise ImportError(
+        "SimpleHTR training requires additional dependencies. "
+        "Install with: uv add xournalpp_htr[training-simple-htr]"
+    ) from e

--- a/xournalpp_htr/training/simple_htr/config.py
+++ b/xournalpp_htr/training/simple_htr/config.py
@@ -23,7 +23,7 @@ class TrainingConfig:
     learning_rate: float = 0.001
     batch_size: int = 64
     epoch_max: int = 100
-    patience_max: int = 15
+    patience_max: int = 25
     val_epoch: int = 1
     num_workers: int = 4
 

--- a/xournalpp_htr/training/simple_htr/config.py
+++ b/xournalpp_htr/training/simple_htr/config.py
@@ -1,0 +1,57 @@
+"""Hydra structured config for SimpleHTR training and inference.
+
+All model/training constants live here as a single source of truth.
+Training uses ``@hydra.main`` to parse overrides from the CLI or YAML;
+other scripts (infer, export, demo) import the defaults directly.
+"""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ModelConfig:
+    input_height: int = 32
+    input_width: int = 128
+    cnn_channels: tuple = (32, 64, 128, 128, 256)
+    rnn_hidden: int = 256
+    rnn_layers: int = 2
+    dropout: float = 0.0
+
+
+@dataclass
+class TrainingConfig:
+    learning_rate: float = 0.001
+    batch_size: int = 64
+    epoch_max: int = 100
+    patience_max: int = 15
+    val_epoch: int = 1
+    num_workers: int = 4
+
+
+@dataclass
+class DataConfig:
+    data_path: str | None = None
+    cache_path: str = "dataset_cache.pickle"
+    percent_train_data: int = 95
+    shuffle_data_loader: bool = True
+
+
+@dataclass
+class SeedConfig:
+    split: int = 42
+    model: int = 1337
+
+
+@dataclass
+class AugmentationConfig:
+    enabled: bool = False
+
+
+@dataclass
+class SimpleHTRConfig:
+    model: ModelConfig = field(default_factory=ModelConfig)
+    training: TrainingConfig = field(default_factory=TrainingConfig)
+    data: DataConfig = field(default_factory=DataConfig)
+    seed: SeedConfig = field(default_factory=SeedConfig)
+    augmentation: AugmentationConfig = field(default_factory=AugmentationConfig)
+    output_path: str = "outputs"

--- a/xournalpp_htr/training/simple_htr/config.py
+++ b/xournalpp_htr/training/simple_htr/config.py
@@ -6,6 +6,7 @@ other scripts (infer, export, demo) import the defaults directly.
 """
 
 from dataclasses import dataclass, field
+from pathlib import Path
 
 
 @dataclass
@@ -55,3 +56,11 @@ class SimpleHTRConfig:
     seed: SeedConfig = field(default_factory=SeedConfig)
     augmentation: AugmentationConfig = field(default_factory=AugmentationConfig)
     output_path: str = "outputs"
+
+
+def load_model_config(checkpoint_dir: Path) -> ModelConfig:
+    """Load ``ModelConfig`` from a training run's ``config.yaml``."""
+    from omegaconf import OmegaConf
+
+    cfg = OmegaConf.load(checkpoint_dir / "config.yaml")
+    return ModelConfig(**OmegaConf.to_container(cfg.model))

--- a/xournalpp_htr/training/simple_htr/dataset.py
+++ b/xournalpp_htr/training/simple_htr/dataset.py
@@ -18,7 +18,7 @@ from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
 
-CACHE_VERSION = "v2"
+CACHE_VERSION = "v3"
 
 
 def build_charset(texts: List[str]) -> List[str]:
@@ -37,16 +37,28 @@ def preprocess_image(
     img: np.ndarray, target_height: int, target_width: int
 ) -> np.ndarray:
     h, w = img.shape[:2]
-    scale = target_height / h
-    new_w = min(int(w * scale), target_width)
-    resized = cv2.resize(img, (new_w, target_height))
+    scale = min(target_width / w, target_height / h)
+    new_w = int(w * scale)
+    new_h = int(h * scale)
+    resized = cv2.resize(img, (new_w, new_h))
 
-    padded = np.ones((target_height, target_width), dtype=np.uint8) * 255
-    padded[:, :new_w] = resized
-    return padded
+    canvas = np.ones((target_height, target_width), dtype=np.uint8) * 255
+    y_off = (target_height - new_h) // 2
+    x_off = (target_width - new_w) // 2
+    canvas[y_off : y_off + new_h, x_off : x_off + new_w] = resized
+    return canvas
 
 
 def _apply_augmentation(img: np.ndarray) -> np.ndarray:
+    if np.random.random() < 0.25:
+        kernel_size = np.random.choice([3, 5, 7])
+        if img.dtype != np.uint8:
+            img_uint8 = ((img + 0.5) * 255).clip(0, 255).astype(np.uint8)
+            img_uint8 = cv2.GaussianBlur(img_uint8, (kernel_size, kernel_size), 0)
+            img = img_uint8.astype(np.float32) / 255.0 - 0.5
+        else:
+            img = cv2.GaussianBlur(img, (kernel_size, kernel_size), 0)
+
     if np.random.random() < 0.5:
         img_min, img_max = img.min(), img.max()
         if img_max - img_min > 1e-6:
@@ -59,7 +71,7 @@ def _apply_augmentation(img: np.ndarray) -> np.ndarray:
         img = img + noise
 
     if np.random.random() < 0.2:
-        kernel = np.ones((2, 2), np.uint8)
+        kernel = np.ones((3, 3), np.uint8)
         if img.dtype != np.uint8:
             img_uint8 = ((img + 0.5) * 255).clip(0, 255).astype(np.uint8)
         else:
@@ -72,6 +84,28 @@ def _apply_augmentation(img: np.ndarray) -> np.ndarray:
             img = img_uint8.astype(np.float32) / 255.0 - 0.5
         else:
             img = img_uint8
+
+    if np.random.random() < 0.5:
+        h, w = img.shape[:2]
+        if img.dtype != np.uint8:
+            img_uint8 = ((img + 0.5) * 255).clip(0, 255).astype(np.uint8)
+        else:
+            img_uint8 = img
+        scale = np.random.uniform(0.75, 1.05)
+        new_h, new_w = int(h * scale), int(w * scale)
+        resized = cv2.resize(img_uint8, (new_w, new_h))
+        # Random position on white canvas
+        canvas = np.ones((h, w), dtype=np.uint8) * 255
+        paste_h, paste_w = min(new_h, h), min(new_w, w)
+        max_y = max(h - paste_h, 0)
+        max_x = max(w - paste_w, 0)
+        y = np.random.randint(0, max_y + 1)
+        x = np.random.randint(0, max_x + 1)
+        canvas[y : y + paste_h, x : x + paste_w] = resized[:paste_h, :paste_w]
+        if img.dtype != np.uint8:
+            img = canvas.astype(np.float32) / 255.0 - 0.5
+        else:
+            img = canvas
 
     return img
 

--- a/xournalpp_htr/training/simple_htr/dataset.py
+++ b/xournalpp_htr/training/simple_htr/dataset.py
@@ -96,15 +96,14 @@ class IAM_Words_Dataset(Dataset):
 
     def __init__(
         self,
-        root_dir: Path,
         target_height: int,
         target_width: int,
+        root_dir: Path | None = None,
         force_rebuild_cache: bool = False,
         augment: bool = False,
         cache_path: Path = Path("dataset_cache.pickle"),
     ):
         super().__init__()
-        self.root_dir = root_dir
         self.target_height = target_height
         self.target_width = target_width
         self.augment = augment
@@ -117,6 +116,14 @@ class IAM_Words_Dataset(Dataset):
             if self._load_from_cache(cache_path):
                 return
             logger.warning("Cache version mismatch, rebuilding.")
+
+        if root_dir is None:
+            from xournalpp_htr.xio import load_IAM_DB_dataset
+
+            root_dir = load_IAM_DB_dataset()
+            print(f"Resolved IAM-DB dataset from HuggingFace Hub: {root_dir}")
+
+        self.root_dir = root_dir
         print(f"Building and caching data from {self.root_dir}...")
         self._preprocess_and_cache(cache_path)
 

--- a/xournalpp_htr/training/simple_htr/dataset.py
+++ b/xournalpp_htr/training/simple_htr/dataset.py
@@ -18,22 +18,19 @@ from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
 
-CACHE_VERSION = "v1"
-
-CHARSET = list(
-    " !\"#&'()*+,-./0123456789:;?ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-)
-
-CHAR_TO_IDX = {c: i for i, c in enumerate(CHARSET)}
-IDX_TO_CHAR = dict(enumerate(CHARSET))
+CACHE_VERSION = "v2"
 
 
-def encode_text(text: str) -> List[int]:
-    return [CHAR_TO_IDX[c] for c in text if c in CHAR_TO_IDX]
+def build_charset(texts: List[str]) -> List[str]:
+    return sorted({c for t in texts for c in t})
 
 
-def decode_indices(indices: List[int]) -> str:
-    return "".join(IDX_TO_CHAR[i] for i in indices if i in IDX_TO_CHAR)
+def encode_text(text: str, char_to_idx: dict) -> List[int]:
+    return [char_to_idx[c] for c in text if c in char_to_idx]
+
+
+def decode_indices(indices: List[int], idx_to_char: dict) -> str:
+    return "".join(idx_to_char[i] for i in indices if i in idx_to_char)
 
 
 def preprocess_image(
@@ -111,6 +108,9 @@ class IAM_Words_Dataset(Dataset):
         self.img_cache: List[np.ndarray] = []
         self.text_cache: List[str] = []
         self.filename_cache: List[str] = []
+        self.charset: List[str] = []
+        self.char_to_idx: dict = {}
+        self.idx_to_char: dict = {}
 
         if cache_path.exists() and not force_rebuild_cache:
             if self._load_from_cache(cache_path):
@@ -127,12 +127,18 @@ class IAM_Words_Dataset(Dataset):
         print(f"Building and caching data from {self.root_dir}...")
         self._preprocess_and_cache(cache_path)
 
+    def _init_charset(self, charset: List[str]):
+        self.charset = charset
+        self.char_to_idx = {c: i for i, c in enumerate(charset)}
+        self.idx_to_char = dict(enumerate(charset))
+
     def _load_from_cache(self, cache_path: Path) -> bool:
         print(f"Loading cached data from {cache_path}...")
         with open(cache_path, "rb") as f:
             payload = pickle.load(f)
         if isinstance(payload, dict) and payload.get("version") == CACHE_VERSION:
             self.img_cache, self.text_cache, self.filename_cache = payload["data"]
+            self._init_charset(payload["charset"])
             return True
         return False
 
@@ -160,12 +166,17 @@ class IAM_Words_Dataset(Dataset):
             self.text_cache.append(text)
             self.filename_cache.append(word_id)
 
-        print(f"Preprocessing complete. {len(self.img_cache)} samples loaded.")
+        self._init_charset(build_charset(self.text_cache))
+        print(
+            f"Preprocessing complete. {len(self.img_cache)} samples loaded, "
+            f"{len(self.charset)} unique characters."
+        )
         print(f"Saving cache to {cache_path}...")
         with open(cache_path, "wb") as f:
             pickle.dump(
                 {
                     "version": CACHE_VERSION,
+                    "charset": self.charset,
                     "data": [
                         self.img_cache,
                         self.text_cache,
@@ -192,10 +203,8 @@ class IAM_Words_Dataset(Dataset):
                     continue
                 word_id = parts[0]
                 text = parts[-1]
-                # words.txt uses | for space within a word (rare)
                 text = text.replace("|", " ")
-                if all(c in CHAR_TO_IDX for c in text):
-                    entries.append((word_id, text))
+                entries.append((word_id, text))
         return entries
 
     def __len__(self) -> int:
@@ -210,7 +219,7 @@ class IAM_Words_Dataset(Dataset):
         if self.augment:
             image = _apply_augmentation(image)
 
-        encoded = encode_text(text)
+        encoded = encode_text(text, self.char_to_idx)
         return {
             "image": image,
             "text": text,

--- a/xournalpp_htr/training/simple_htr/dataset.py
+++ b/xournalpp_htr/training/simple_htr/dataset.py
@@ -1,0 +1,238 @@
+"""IAM word-level dataset loading for SimpleHTR training.
+
+Loads pre-cropped word images from the IAM Handwriting Database
+(``data/words/`` directory) with transcriptions from ``data/ascii/words.txt``.
+Requires the ``training-simple-htr`` extra (torch).
+"""
+
+import logging
+import pickle
+from pathlib import Path
+from typing import List, Tuple, TypedDict
+
+import cv2
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
+
+CACHE_VERSION = "v1"
+
+CHARSET = list(
+    " !\"#&'()*+,-./0123456789:;?ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+)
+
+CHAR_TO_IDX = {c: i for i, c in enumerate(CHARSET)}
+IDX_TO_CHAR = dict(enumerate(CHARSET))
+
+
+def encode_text(text: str) -> List[int]:
+    return [CHAR_TO_IDX[c] for c in text if c in CHAR_TO_IDX]
+
+
+def decode_indices(indices: List[int]) -> str:
+    return "".join(IDX_TO_CHAR[i] for i in indices if i in IDX_TO_CHAR)
+
+
+def preprocess_image(
+    img: np.ndarray, target_height: int, target_width: int
+) -> np.ndarray:
+    h, w = img.shape[:2]
+    scale = target_height / h
+    new_w = min(int(w * scale), target_width)
+    resized = cv2.resize(img, (new_w, target_height))
+
+    padded = np.ones((target_height, target_width), dtype=np.uint8) * 255
+    padded[:, :new_w] = resized
+    return padded
+
+
+def _apply_augmentation(img: np.ndarray) -> np.ndarray:
+    if np.random.random() < 0.5:
+        img_min, img_max = img.min(), img.max()
+        if img_max - img_min > 1e-6:
+            img = (img - img_min) / (img_max - img_min) - 0.5
+        factor = np.random.uniform(0.5, 1.0)
+        img = img * factor
+
+    if np.random.random() < 0.25:
+        noise = np.random.uniform(-0.05, 0.05, size=img.shape).astype(np.float32)
+        img = img + noise
+
+    if np.random.random() < 0.2:
+        kernel = np.ones((2, 2), np.uint8)
+        if img.dtype != np.uint8:
+            img_uint8 = ((img + 0.5) * 255).clip(0, 255).astype(np.uint8)
+        else:
+            img_uint8 = img
+        if np.random.random() < 0.5:
+            img_uint8 = cv2.erode(img_uint8, kernel, iterations=1)
+        else:
+            img_uint8 = cv2.dilate(img_uint8, kernel, iterations=1)
+        if img.dtype != np.uint8:
+            img = img_uint8.astype(np.float32) / 255.0 - 0.5
+        else:
+            img = img_uint8
+
+    return img
+
+
+class IAM_Words_Element(TypedDict):
+    image: np.ndarray
+    text: str
+    encoded: List[int]
+    filename: str
+
+
+class IAM_Words_Dataset(Dataset):
+    """Loads, pre-processes and caches the IAM word-level dataset.
+
+    Reads word images from ``data/words/`` and ground-truth transcriptions
+    from ``data/ascii/words.txt``. Only words with segmentation status ``ok``
+    are included. Compatible with PyTorch's ``DataLoader``.
+    """
+
+    def __init__(
+        self,
+        root_dir: Path,
+        target_height: int,
+        target_width: int,
+        force_rebuild_cache: bool = False,
+        augment: bool = False,
+        cache_path: Path = Path("dataset_cache.pickle"),
+    ):
+        super().__init__()
+        self.root_dir = root_dir
+        self.target_height = target_height
+        self.target_width = target_width
+        self.augment = augment
+
+        self.img_cache: List[np.ndarray] = []
+        self.text_cache: List[str] = []
+        self.filename_cache: List[str] = []
+
+        if cache_path.exists() and not force_rebuild_cache:
+            if self._load_from_cache(cache_path):
+                return
+            logger.warning("Cache version mismatch, rebuilding.")
+        print(f"Building and caching data from {self.root_dir}...")
+        self._preprocess_and_cache(cache_path)
+
+    def _load_from_cache(self, cache_path: Path) -> bool:
+        print(f"Loading cached data from {cache_path}...")
+        with open(cache_path, "rb") as f:
+            payload = pickle.load(f)
+        if isinstance(payload, dict) and payload.get("version") == CACHE_VERSION:
+            self.img_cache, self.text_cache, self.filename_cache = payload["data"]
+            return True
+        return False
+
+    def _preprocess_and_cache(self, cache_path: Path):
+        words_file = self.root_dir / "ascii" / "words.txt"
+        words_dir = self.root_dir / "words"
+
+        entries = self._parse_words_file(words_file)
+        print(f"Found {len(entries)} word entries. Processing...")
+
+        for word_id, text in tqdm(entries, desc="Preprocessing IAM Words"):
+            parts = word_id.split("-")
+            img_path = (
+                words_dir / parts[0] / f"{parts[0]}-{parts[1]}" / f"{word_id}.png"
+            )
+            if not img_path.exists():
+                continue
+
+            img = cv2.imread(str(img_path), cv2.IMREAD_GRAYSCALE)
+            if img is None:
+                continue
+
+            img = preprocess_image(img, self.target_height, self.target_width)
+            self.img_cache.append(img)
+            self.text_cache.append(text)
+            self.filename_cache.append(word_id)
+
+        print(f"Preprocessing complete. {len(self.img_cache)} samples loaded.")
+        print(f"Saving cache to {cache_path}...")
+        with open(cache_path, "wb") as f:
+            pickle.dump(
+                {
+                    "version": CACHE_VERSION,
+                    "data": [
+                        self.img_cache,
+                        self.text_cache,
+                        self.filename_cache,
+                    ],
+                },
+                f,
+            )
+        print("Cache saved successfully.")
+
+    @staticmethod
+    def _parse_words_file(words_file: Path) -> List[Tuple[str, str]]:
+        entries = []
+        with open(words_file) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                parts = line.split()
+                if len(parts) < 9:
+                    continue
+                seg_status = parts[1]
+                if seg_status != "ok":
+                    continue
+                word_id = parts[0]
+                text = parts[-1]
+                # words.txt uses | for space within a word (rare)
+                text = text.replace("|", " ")
+                if all(c in CHAR_TO_IDX for c in text):
+                    entries.append((word_id, text))
+        return entries
+
+    def __len__(self) -> int:
+        return len(self.img_cache)
+
+    def __getitem__(self, idx: int) -> IAM_Words_Element:
+        image = self.img_cache[idx].copy()
+        text = self.text_cache[idx]
+
+        image = image.astype(np.float32) / 255.0 - 0.5
+
+        if self.augment:
+            image = _apply_augmentation(image)
+
+        encoded = encode_text(text)
+        return {
+            "image": image,
+            "text": text,
+            "encoded": encoded,
+            "filename": self.filename_cache[idx],
+        }
+
+
+class Dataloader_Element(TypedDict):
+    images: torch.Tensor
+    texts: List[str]
+    encoded: List[List[int]]
+    target_lengths: torch.Tensor
+    targets: torch.Tensor
+
+
+def custom_collate_fn(batch: List[IAM_Words_Element]) -> Dataloader_Element:
+    """Collate ``IAM_Words_Element`` batches for the ``DataLoader``."""
+    images = torch.from_numpy(
+        np.stack([s["image"][None, ...] for s in batch], axis=0).astype(np.float32)
+    )
+    texts = [s["text"] for s in batch]
+    encoded = [s["encoded"] for s in batch]
+    target_lengths = torch.tensor([len(e) for e in encoded], dtype=torch.long)
+    targets = torch.tensor([idx for e in encoded for idx in e], dtype=torch.long)
+    return {
+        "images": images,
+        "texts": texts,
+        "encoded": encoded,
+        "target_lengths": target_lengths,
+        "targets": targets,
+    }

--- a/xournalpp_htr/training/simple_htr/demo.py
+++ b/xournalpp_htr/training/simple_htr/demo.py
@@ -19,21 +19,28 @@ from xournalpp_htr.training.simple_htr.dataset import CHARSET
 from xournalpp_htr.training.simple_htr.infer import run_image_through_network
 
 
-def _plot_ctc_matrix(log_probs: np.ndarray) -> plt.Figure:
-    """Visualise the CTC output matrix (seq_len x num_classes) as a heatmap."""
+def _plot_ctc_matrix(log_probs: np.ndarray, top_k: int = 10) -> plt.Figure:
+    """Visualise the CTC output matrix, showing only the top-k characters."""
     probs = np.exp(log_probs)  # (seq_len, num_classes)
 
     labels = list(CHARSET) + ["∅"]
 
-    fig, ax = plt.subplots(figsize=(max(10, probs.shape[0] * 0.4), 6))
-    im = ax.imshow(probs.T, aspect="auto", cmap="Blues", vmin=0, vmax=1)
+    total_prob = probs.sum(axis=0)
+    top_indices = np.argsort(total_prob)[::-1][:top_k]
+    top_indices = np.sort(top_indices)
+
+    probs_top = probs[:, top_indices]
+    labels_top = [labels[i] for i in top_indices]
+
+    fig, ax = plt.subplots(figsize=(max(10, probs.shape[0] * 0.4), 4))
+    im = ax.imshow(probs_top.T, aspect="auto", cmap="Blues", vmin=0, vmax=1)
     ax.set_xlabel("Timestep", fontsize=12)
     ax.set_ylabel("Character", fontsize=12)
-    ax.set_title("CTC output probabilities", fontsize=14)
+    ax.set_title(f"CTC output probabilities (top {top_k} characters)", fontsize=14)
     ax.set_xticks(range(probs.shape[0]))
-    ax.set_xticklabels(range(probs.shape[0]), fontsize=7)
-    ax.set_yticks(range(len(labels)))
-    ax.set_yticklabels(labels, fontsize=7, fontfamily="monospace")
+    ax.set_xticklabels(range(probs.shape[0]), fontsize=8)
+    ax.set_yticks(range(len(labels_top)))
+    ax.set_yticklabels(labels_top, fontsize=11, fontfamily="monospace")
     fig.colorbar(im, ax=ax, label="Probability", shrink=0.8)
     fig.tight_layout()
     return fig

--- a/xournalpp_htr/training/simple_htr/demo.py
+++ b/xournalpp_htr/training/simple_htr/demo.py
@@ -15,15 +15,16 @@ import gradio as gr
 import matplotlib.pyplot as plt
 import numpy as np
 
-from xournalpp_htr.training.simple_htr.dataset import CHARSET
 from xournalpp_htr.training.simple_htr.infer import run_image_through_network
 
 
-def _plot_ctc_matrix(log_probs: np.ndarray, top_k: int = 10) -> plt.Figure:
+def _plot_ctc_matrix(
+    log_probs: np.ndarray, charset: list[str], top_k: int = 10
+) -> plt.Figure:
     """Visualise the CTC output matrix, showing only the top-k characters."""
     probs = np.exp(log_probs)  # (seq_len, num_classes)
 
-    labels = list(CHARSET) + ["∅"]
+    labels = list(charset) + ["∅"]
 
     total_prob = probs.sum(axis=0)
     top_indices = np.argsort(total_prob)[::-1][:top_k]
@@ -59,7 +60,7 @@ def build_demo(model_path: Path, device_selection: str) -> gr.Blocks:
             model_path=model_path,
             device=device_selection,
         )
-        fig = _plot_ctc_matrix(result["log_probs"])
+        fig = _plot_ctc_matrix(result["log_probs"], result["charset"])
         return result["text"], fig
 
     def process_sketch(sketch: dict) -> tuple[str, plt.Figure]:

--- a/xournalpp_htr/training/simple_htr/demo.py
+++ b/xournalpp_htr/training/simple_htr/demo.py
@@ -1,0 +1,80 @@
+"""Local Gradio demo for a trained SimpleHTR checkpoint.
+
+An interactive Gradio app to sanity-check whether a trained checkpoint
+recognises handwritten words. Per ADR 007 it runs **locally**
+(``demo.launch()``); it is not deployed as a HuggingFace Space.
+
+    uv run python -m xournalpp_htr.training.simple_htr.demo --help
+"""
+
+import argparse
+from pathlib import Path
+
+import cv2
+import gradio as gr
+import numpy as np
+
+from xournalpp_htr.training.simple_htr.infer import run_image_through_network
+
+
+def build_demo(model_path: Path, device_selection: str) -> gr.Interface:
+    def process_image(image: np.ndarray) -> str:
+        image_gray = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
+        result = run_image_through_network(
+            image_grayscale=image_gray,
+            model_path=model_path,
+            device=device_selection,
+        )
+        return result["text"]
+
+    return gr.Interface(
+        fn=process_image,
+        inputs=gr.Image(type="numpy", label="Word image"),
+        outputs=gr.Textbox(label="Recognised text"),
+        title="SimpleHTR: Handwritten Word Recognition (local)",
+        description="Recognise a single handwritten word. Upload an image of "
+        "a handwritten word to get the predicted text.",
+        article="""
+        ### About this project
+        Part of **[Xournal++ HTR](https://github.com/PellelNitram/xournalpp_htr)**,
+        an open-source effort to bring handwritten text recognition to
+        [Xournal++](https://github.com/xournalpp/xournalpp).
+
+        The original SimpleHTR model was created by **Harald Scheidl**
+        ([SimpleHTR](https://github.com/githubharald/SimpleHTR)) and is
+        reimplemented here with PyTorch. Thanks Harald!
+        """,
+        cache_examples=False,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--model-path",
+        type=Path,
+        default=Path("best_model.pth"),
+        help="Path to the trained .pth checkpoint.",
+    )
+    parser.add_argument(
+        "--device",
+        choices=["cpu", "cuda", "auto"],
+        default="cpu",
+        help='Inference device. "auto" selects GPU if available.',
+    )
+    parser.add_argument(
+        "--share",
+        action="store_true",
+        help="Expose a temporary public Gradio share link.",
+    )
+    args = parser.parse_args()
+
+    demo = build_demo(args.model_path, args.device)
+    demo.launch(share=args.share)
+
+
+if __name__ == "__main__":
+    main()

--- a/xournalpp_htr/training/simple_htr/demo.py
+++ b/xournalpp_htr/training/simple_htr/demo.py
@@ -12,15 +12,37 @@ from pathlib import Path
 
 import cv2
 import gradio as gr
+import matplotlib.pyplot as plt
 import numpy as np
 
+from xournalpp_htr.training.simple_htr.dataset import CHARSET
 from xournalpp_htr.training.simple_htr.infer import run_image_through_network
 
 
+def _plot_ctc_matrix(log_probs: np.ndarray) -> plt.Figure:
+    """Visualise the CTC output matrix (seq_len x num_classes) as a heatmap."""
+    probs = np.exp(log_probs)  # (seq_len, num_classes)
+
+    labels = list(CHARSET) + ["∅"]
+
+    fig, ax = plt.subplots(figsize=(max(10, probs.shape[0] * 0.4), 6))
+    im = ax.imshow(probs.T, aspect="auto", cmap="Blues", vmin=0, vmax=1)
+    ax.set_xlabel("Timestep", fontsize=12)
+    ax.set_ylabel("Character", fontsize=12)
+    ax.set_title("CTC output probabilities", fontsize=14)
+    ax.set_xticks(range(probs.shape[0]))
+    ax.set_xticklabels(range(probs.shape[0]), fontsize=7)
+    ax.set_yticks(range(len(labels)))
+    ax.set_yticklabels(labels, fontsize=7, fontfamily="monospace")
+    fig.colorbar(im, ax=ax, label="Probability", shrink=0.8)
+    fig.tight_layout()
+    return fig
+
+
 def build_demo(model_path: Path, device_selection: str) -> gr.Blocks:
-    def process_image(image: np.ndarray) -> str:
+    def process_image(image: np.ndarray) -> tuple[str, plt.Figure]:
         if image is None:
-            return ""
+            return "", None
         if len(image.shape) == 3:
             image_gray = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
         else:
@@ -30,14 +52,15 @@ def build_demo(model_path: Path, device_selection: str) -> gr.Blocks:
             model_path=model_path,
             device=device_selection,
         )
-        return result["text"]
+        fig = _plot_ctc_matrix(result["log_probs"])
+        return result["text"], fig
 
-    def process_sketch(sketch: dict) -> str:
+    def process_sketch(sketch: dict) -> tuple[str, plt.Figure]:
         if sketch is None:
-            return ""
+            return "", None
         composite = sketch["composite"]
         if composite is None:
-            return ""
+            return "", None
         return process_image(composite)
 
     article = """
@@ -59,9 +82,12 @@ def build_demo(model_path: Path, device_selection: str) -> gr.Blocks:
             with gr.TabItem("Upload image"):
                 upload_input = gr.Image(type="numpy", label="Word image")
                 upload_output = gr.Textbox(label="Recognised text")
+                upload_plot = gr.Plot(label="CTC output probabilities")
                 upload_btn = gr.Button("Recognise")
                 upload_btn.click(
-                    process_image, inputs=upload_input, outputs=upload_output
+                    process_image,
+                    inputs=upload_input,
+                    outputs=[upload_output, upload_plot],
                 )
 
             with gr.TabItem("Draw"):
@@ -71,9 +97,12 @@ def build_demo(model_path: Path, device_selection: str) -> gr.Blocks:
                     canvas_size=(400, 100),
                 )
                 sketch_output = gr.Textbox(label="Recognised text")
+                sketch_plot = gr.Plot(label="CTC output probabilities")
                 sketch_btn = gr.Button("Recognise")
                 sketch_btn.click(
-                    process_sketch, inputs=sketch_input, outputs=sketch_output
+                    process_sketch,
+                    inputs=sketch_input,
+                    outputs=[sketch_output, sketch_plot],
                 )
 
         gr.Markdown(article)

--- a/xournalpp_htr/training/simple_htr/demo.py
+++ b/xournalpp_htr/training/simple_htr/demo.py
@@ -17,9 +17,14 @@ import numpy as np
 from xournalpp_htr.training.simple_htr.infer import run_image_through_network
 
 
-def build_demo(model_path: Path, device_selection: str) -> gr.Interface:
+def build_demo(model_path: Path, device_selection: str) -> gr.Blocks:
     def process_image(image: np.ndarray) -> str:
-        image_gray = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
+        if image is None:
+            return ""
+        if len(image.shape) == 3:
+            image_gray = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
+        else:
+            image_gray = image
         result = run_image_through_network(
             image_grayscale=image_gray,
             model_path=model_path,
@@ -27,25 +32,53 @@ def build_demo(model_path: Path, device_selection: str) -> gr.Interface:
         )
         return result["text"]
 
-    return gr.Interface(
-        fn=process_image,
-        inputs=gr.Image(type="numpy", label="Word image"),
-        outputs=gr.Textbox(label="Recognised text"),
-        title="SimpleHTR: Handwritten Word Recognition (local)",
-        description="Recognise a single handwritten word. Upload an image of "
-        "a handwritten word to get the predicted text.",
-        article="""
-        ### About this project
-        Part of **[Xournal++ HTR](https://github.com/PellelNitram/xournalpp_htr)**,
-        an open-source effort to bring handwritten text recognition to
-        [Xournal++](https://github.com/xournalpp/xournalpp).
+    def process_sketch(sketch: dict) -> str:
+        if sketch is None:
+            return ""
+        composite = sketch["composite"]
+        if composite is None:
+            return ""
+        return process_image(composite)
 
-        The original SimpleHTR model was created by **Harald Scheidl**
-        ([SimpleHTR](https://github.com/githubharald/SimpleHTR)) and is
-        reimplemented here with PyTorch. Thanks Harald!
-        """,
-        cache_examples=False,
-    )
+    article = """
+    ### About this project
+    Part of **[Xournal++ HTR](https://github.com/PellelNitram/xournalpp_htr)**,
+    an open-source effort to bring handwritten text recognition to
+    [Xournal++](https://github.com/xournalpp/xournalpp).
+
+    The original SimpleHTR model was created by **Harald Scheidl**
+    ([SimpleHTR](https://github.com/githubharald/SimpleHTR)) and is
+    reimplemented here with PyTorch. Thanks Harald!
+    """
+
+    with gr.Blocks(title="SimpleHTR: Handwritten Word Recognition (local)") as demo:
+        gr.Markdown("# SimpleHTR: Handwritten Word Recognition (local)")
+        gr.Markdown("Recognise a single handwritten word. Upload an image or draw one.")
+
+        with gr.Tabs():
+            with gr.TabItem("Upload image"):
+                upload_input = gr.Image(type="numpy", label="Word image")
+                upload_output = gr.Textbox(label="Recognised text")
+                upload_btn = gr.Button("Recognise")
+                upload_btn.click(
+                    process_image, inputs=upload_input, outputs=upload_output
+                )
+
+            with gr.TabItem("Draw"):
+                sketch_input = gr.Sketchpad(
+                    label="Draw a word",
+                    brush=gr.Brush(default_size=3, colors=["black"]),
+                    canvas_size=(400, 100),
+                )
+                sketch_output = gr.Textbox(label="Recognised text")
+                sketch_btn = gr.Button("Recognise")
+                sketch_btn.click(
+                    process_sketch, inputs=sketch_input, outputs=sketch_output
+                )
+
+        gr.Markdown(article)
+
+    return demo
 
 
 def main() -> None:

--- a/xournalpp_htr/training/simple_htr/export.py
+++ b/xournalpp_htr/training/simple_htr/export.py
@@ -18,19 +18,20 @@ from pathlib import Path
 
 import torch
 
+from xournalpp_htr.training.simple_htr.config import ModelConfig, load_model_config
 from xournalpp_htr.training.simple_htr.infer import load_charset
 from xournalpp_htr.training.simple_htr.network import SimpleHTRNet
 
 HF_REPO_ID = "PellelNitram/xournalpp-htr-simple-htr"
 
 
-def build_config(charset: list[str]) -> dict:
+def build_config(charset: list[str], model_cfg: ModelConfig) -> dict:
     num_classes = len(charset) + 1
     return {
         "model_name": "simple_htr",
         "input_size": {
-            "height": SimpleHTRNet.input_height,
-            "width": SimpleHTRNet.input_width,
+            "height": model_cfg.input_height,
+            "width": model_cfg.input_width,
         },
         "charset": charset,
         "num_classes": num_classes,
@@ -47,12 +48,13 @@ def export(checkpoint: Path, output_dir: Path) -> dict:
 
     charset = load_charset(checkpoint)
     num_classes = len(charset) + 1
+    model_cfg = load_model_config(checkpoint.parent)
 
-    net = SimpleHTRNet(num_classes=num_classes)
+    net = SimpleHTRNet(num_classes=num_classes, cfg=model_cfg)
     net.load_state_dict(torch.load(checkpoint, map_location="cpu"))
     net.eval()
 
-    h, w = SimpleHTRNet.input_height, SimpleHTRNet.input_width
+    h, w = model_cfg.input_height, model_cfg.input_width
     dummy_input = torch.zeros(1, 1, h, w, dtype=torch.float32)
 
     onnx_path = output_dir / "model.onnx"
@@ -69,7 +71,7 @@ def export(checkpoint: Path, output_dir: Path) -> dict:
 
     config_path = output_dir / "config.json"
     with open(config_path, "w") as f:
-        json.dump(build_config(charset), f, indent=2)
+        json.dump(build_config(charset, model_cfg), f, indent=2)
 
     print(f"Wrote {onnx_path} and {config_path}")
     return {"onnx": onnx_path, "config": config_path}

--- a/xournalpp_htr/training/simple_htr/export.py
+++ b/xournalpp_htr/training/simple_htr/export.py
@@ -18,21 +18,22 @@ from pathlib import Path
 
 import torch
 
-from xournalpp_htr.training.simple_htr.dataset import CHARSET
+from xournalpp_htr.training.simple_htr.infer import load_charset
 from xournalpp_htr.training.simple_htr.network import SimpleHTRNet
 
 HF_REPO_ID = "PellelNitram/xournalpp-htr-simple-htr"
 
 
-def build_config() -> dict:
+def build_config(charset: list[str]) -> dict:
+    num_classes = len(charset) + 1
     return {
         "model_name": "simple_htr",
         "input_size": {
             "height": SimpleHTRNet.input_height,
             "width": SimpleHTRNet.input_width,
         },
-        "charset": CHARSET,
-        "num_classes": SimpleHTRNet.num_classes,
+        "charset": charset,
+        "num_classes": num_classes,
         "normalization": {
             "scale": 255.0,
             "shift": -0.5,
@@ -44,7 +45,10 @@ def export(checkpoint: Path, output_dir: Path) -> dict:
     """Export ``checkpoint`` to ``output_dir`` as ``model.onnx`` + ``config.json``."""
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    net = SimpleHTRNet()
+    charset = load_charset(checkpoint)
+    num_classes = len(charset) + 1
+
+    net = SimpleHTRNet(num_classes=num_classes)
     net.load_state_dict(torch.load(checkpoint, map_location="cpu"))
     net.eval()
 
@@ -65,7 +69,7 @@ def export(checkpoint: Path, output_dir: Path) -> dict:
 
     config_path = output_dir / "config.json"
     with open(config_path, "w") as f:
-        json.dump(build_config(), f, indent=2)
+        json.dump(build_config(charset), f, indent=2)
 
     print(f"Wrote {onnx_path} and {config_path}")
     return {"onnx": onnx_path, "config": config_path}

--- a/xournalpp_htr/training/simple_htr/export.py
+++ b/xournalpp_htr/training/simple_htr/export.py
@@ -1,0 +1,116 @@
+"""Export a trained SimpleHTR checkpoint to the ONNX inference artifact.
+
+ADR 006: ONNX is the canonical inference format. This script produces the two
+files consumed by :class:`xournalpp_htr.inference_models.SimpleHTRModel`:
+
+* ``model.onnx``  -- the network graph.
+* ``config.json`` -- charset, input dimensions, and pre-processing parameters.
+
+Usage::
+
+    uv run python -m xournalpp_htr.training.simple_htr.export \\
+        --checkpoint best_model.pth --output-dir exports/
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+
+from xournalpp_htr.training.simple_htr.dataset import CHARSET
+from xournalpp_htr.training.simple_htr.network import SimpleHTRNet
+
+HF_REPO_ID = "PellelNitram/xournalpp-htr-simple-htr"
+
+
+def build_config() -> dict:
+    return {
+        "model_name": "simple_htr",
+        "input_size": {
+            "height": SimpleHTRNet.input_height,
+            "width": SimpleHTRNet.input_width,
+        },
+        "charset": CHARSET,
+        "num_classes": SimpleHTRNet.num_classes,
+        "normalization": {
+            "scale": 255.0,
+            "shift": -0.5,
+        },
+    }
+
+
+def export(checkpoint: Path, output_dir: Path) -> dict:
+    """Export ``checkpoint`` to ``output_dir`` as ``model.onnx`` + ``config.json``."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    net = SimpleHTRNet()
+    net.load_state_dict(torch.load(checkpoint, map_location="cpu"))
+    net.eval()
+
+    h, w = SimpleHTRNet.input_height, SimpleHTRNet.input_width
+    dummy_input = torch.zeros(1, 1, h, w, dtype=torch.float32)
+
+    onnx_path = output_dir / "model.onnx"
+    torch.onnx.export(
+        net,
+        dummy_input,
+        str(onnx_path),
+        input_names=["image"],
+        output_names=["log_probs"],
+        dynamic_axes={"image": {0: "batch"}, "log_probs": {1: "batch"}},
+        opset_version=17,
+        dynamo=False,
+    )
+
+    config_path = output_dir / "config.json"
+    with open(config_path, "w") as f:
+        json.dump(build_config(), f, indent=2)
+
+    print(f"Wrote {onnx_path} and {config_path}")
+    return {"onnx": onnx_path, "config": config_path}
+
+
+def upload_to_hub(output_dir: Path, repo_id: str = HF_REPO_ID) -> None:
+    """Upload ``model.onnx`` + ``config.json`` to HF Hub (ADR 006 section 1)."""
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+    api.create_repo(repo_id, exist_ok=True)
+    for filename in ("model.onnx", "config.json"):
+        api.upload_file(
+            path_or_fileobj=str(output_dir / filename),
+            path_in_repo=filename,
+            repo_id=repo_id,
+        )
+    print(f"Uploaded model.onnx + config.json to {repo_id}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        default=Path("best_model.pth"),
+        help="Path to the trained .pth checkpoint.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("exports"),
+        help="Directory to write model.onnx and config.json into.",
+    )
+    parser.add_argument(
+        "--upload",
+        action="store_true",
+        help="After export, upload to HF Hub (requires authentication).",
+    )
+    args = parser.parse_args()
+
+    export(args.checkpoint, args.output_dir)
+    if args.upload:
+        upload_to_hub(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/xournalpp_htr/training/simple_htr/infer.py
+++ b/xournalpp_htr/training/simple_htr/infer.py
@@ -40,4 +40,5 @@ def run_image_through_network(
     return {
         "text": decoded[0],
         "model_input_image": normalized,
+        "log_probs": log_probs[:, 0, :].cpu().numpy(),
     }

--- a/xournalpp_htr/training/simple_htr/infer.py
+++ b/xournalpp_htr/training/simple_htr/infer.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import numpy as np
 import torch
 
+from xournalpp_htr.training.simple_htr.config import load_model_config
 from xournalpp_htr.training.simple_htr.dataset import preprocess_image
 from xournalpp_htr.training.simple_htr.network import SimpleHTRNet, greedy_decode
 from xournalpp_htr.training.simple_htr.utils import get_device
@@ -30,14 +31,15 @@ def run_image_through_network(
     device = get_device(device)
     charset = load_charset(model_path)
     num_classes = len(charset) + 1
+    model_cfg = load_model_config(model_path.parent)
 
-    model = SimpleHTRNet(num_classes=num_classes)
+    model = SimpleHTRNet(num_classes=num_classes, cfg=model_cfg)
     model.load_state_dict(torch.load(model_path, map_location=device))
     model.to(device)
     model.eval()
 
     preprocessed = preprocess_image(
-        image_grayscale, SimpleHTRNet.input_height, SimpleHTRNet.input_width
+        image_grayscale, model_cfg.input_height, model_cfg.input_width
     )
     normalized = preprocessed.astype(np.float32) / 255.0 - 0.5
     tensor_input = torch.from_numpy(normalized[None, None, :, :]).to(device)

--- a/xournalpp_htr/training/simple_htr/infer.py
+++ b/xournalpp_htr/training/simple_htr/infer.py
@@ -5,6 +5,7 @@ checkpoint* directly (before/without an ONNX export). Production inference uses
 the ONNX path via :class:`xournalpp_htr.inference_models.SimpleHTRModel`.
 """
 
+import json
 from pathlib import Path
 
 import numpy as np
@@ -15,13 +16,22 @@ from xournalpp_htr.training.simple_htr.network import SimpleHTRNet, greedy_decod
 from xournalpp_htr.training.simple_htr.utils import get_device
 
 
+def load_charset(model_path: Path) -> list[str]:
+    charset_path = model_path.parent / "charset.json"
+    with open(charset_path) as f:
+        return json.load(f)
+
+
 def run_image_through_network(
     image_grayscale: np.ndarray,
     model_path: Path = Path("best_model.pth"),
     device: str = "auto",
 ) -> dict:
     device = get_device(device)
-    model = SimpleHTRNet()
+    charset = load_charset(model_path)
+    num_classes = len(charset) + 1
+
+    model = SimpleHTRNet(num_classes=num_classes)
     model.load_state_dict(torch.load(model_path, map_location=device))
     model.to(device)
     model.eval()
@@ -35,10 +45,11 @@ def run_image_through_network(
     with torch.no_grad():
         log_probs = model(tensor_input)
 
-    decoded = greedy_decode(log_probs)
+    decoded = greedy_decode(log_probs, charset)
 
     return {
         "text": decoded[0],
         "model_input_image": normalized,
         "log_probs": log_probs[:, 0, :].cpu().numpy(),
+        "charset": charset,
     }

--- a/xournalpp_htr/training/simple_htr/infer.py
+++ b/xournalpp_htr/training/simple_htr/infer.py
@@ -1,0 +1,43 @@
+"""Local torch inference from a ``.pth`` checkpoint.
+
+Used by the Gradio demo and the model-inspection notebook to run the *trained
+checkpoint* directly (before/without an ONNX export). Production inference uses
+the ONNX path via :class:`xournalpp_htr.inference_models.SimpleHTRModel`.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from xournalpp_htr.training.simple_htr.dataset import preprocess_image
+from xournalpp_htr.training.simple_htr.network import SimpleHTRNet, greedy_decode
+from xournalpp_htr.training.simple_htr.utils import get_device
+
+
+def run_image_through_network(
+    image_grayscale: np.ndarray,
+    model_path: Path = Path("best_model.pth"),
+    device: str = "auto",
+) -> dict:
+    device = get_device(device)
+    model = SimpleHTRNet()
+    model.load_state_dict(torch.load(model_path, map_location=device))
+    model.to(device)
+    model.eval()
+
+    preprocessed = preprocess_image(
+        image_grayscale, SimpleHTRNet.input_height, SimpleHTRNet.input_width
+    )
+    normalized = preprocessed.astype(np.float32) / 255.0 - 0.5
+    tensor_input = torch.from_numpy(normalized[None, None, :, :]).to(device)
+
+    with torch.no_grad():
+        log_probs = model(tensor_input)
+
+    decoded = greedy_decode(log_probs)
+
+    return {
+        "text": decoded[0],
+        "model_input_image": normalized,
+    }

--- a/xournalpp_htr/training/simple_htr/network.py
+++ b/xournalpp_htr/training/simple_htr/network.py
@@ -8,25 +8,26 @@ character-level logits for CTC decoding.
 Requires the ``training-simple-htr`` extra (torch).
 """
 
+from typing import List
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
 from xournalpp_htr.training.simple_htr.config import ModelConfig
-from xournalpp_htr.training.simple_htr.dataset import CHARSET
 
 
 class SimpleHTRNet(nn.Module):
     _defaults = ModelConfig()
     input_height = _defaults.input_height
     input_width = _defaults.input_width
-    num_classes = len(CHARSET) + 1  # +1 for CTC blank
 
-    def __init__(self, cfg: ModelConfig | None = None):
+    def __init__(self, num_classes: int, cfg: ModelConfig | None = None):
         super().__init__()
         if cfg is None:
             cfg = ModelConfig()
 
+        self.num_classes = num_classes
         channels = cfg.cnn_channels
 
         self.cnn = nn.Sequential(
@@ -69,7 +70,7 @@ class SimpleHTRNet(nn.Module):
             dropout=cfg.dropout if cfg.rnn_layers > 1 else 0.0,
         )
 
-        self.fc = nn.Linear(cfg.rnn_hidden * 2, self.num_classes)
+        self.fc = nn.Linear(cfg.rnn_hidden * 2, num_classes)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward pass.
@@ -95,25 +96,25 @@ def compute_ctc_loss(
     log_probs: torch.Tensor,
     targets: torch.Tensor,
     target_lengths: torch.Tensor,
+    blank: int,
 ) -> torch.Tensor:
     input_lengths = torch.full(
         (log_probs.size(1),), log_probs.size(0), dtype=torch.long
     )
-    return F.ctc_loss(
-        log_probs, targets, input_lengths, target_lengths, blank=len(CHARSET)
-    )
+    return F.ctc_loss(log_probs, targets, input_lengths, target_lengths, blank=blank)
 
 
-def greedy_decode(log_probs: torch.Tensor) -> list[str]:
+def greedy_decode(log_probs: torch.Tensor, charset: List[str]) -> list[str]:
     """Best-path CTC decoding.
 
     Args:
         log_probs: (seq_len, batch, num_classes) from ``forward()``.
+        charset: list of characters (blank index = len(charset)).
 
     Returns:
         List of decoded strings, one per batch element.
     """
-    blank = len(CHARSET)
+    blank = len(charset)
     predictions = log_probs.argmax(dim=2).permute(1, 0)  # (batch, seq_len)
     results = []
     for pred in predictions:
@@ -122,7 +123,7 @@ def greedy_decode(log_probs: torch.Tensor) -> list[str]:
         for idx in pred:
             idx = idx.item()
             if idx != prev and idx != blank:
-                chars.append(CHARSET[idx])
+                chars.append(charset[idx])
             prev = idx
         results.append("".join(chars))
     return results

--- a/xournalpp_htr/training/simple_htr/network.py
+++ b/xournalpp_htr/training/simple_htr/network.py
@@ -18,10 +18,6 @@ from xournalpp_htr.training.simple_htr.config import ModelConfig
 
 
 class SimpleHTRNet(nn.Module):
-    _defaults = ModelConfig()
-    input_height = _defaults.input_height
-    input_width = _defaults.input_width
-
     def __init__(self, num_classes: int, cfg: ModelConfig | None = None):
         super().__init__()
         if cfg is None:

--- a/xournalpp_htr/training/simple_htr/network.py
+++ b/xournalpp_htr/training/simple_htr/network.py
@@ -1,0 +1,128 @@
+"""SimpleHTR network architecture and CTC loss.
+
+Reimplementation of `Harald Scheidl's SimpleHTR
+<https://github.com/githubharald/SimpleHTR>`_: 5 CNN layers, 2 bidirectional
+LSTM layers, and a CTC output layer. Takes a grayscale word image and produces
+character-level logits for CTC decoding.
+
+Requires the ``training-simple-htr`` extra (torch).
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from xournalpp_htr.training.simple_htr.config import ModelConfig
+from xournalpp_htr.training.simple_htr.dataset import CHARSET
+
+
+class SimpleHTRNet(nn.Module):
+    _defaults = ModelConfig()
+    input_height = _defaults.input_height
+    input_width = _defaults.input_width
+    num_classes = len(CHARSET) + 1  # +1 for CTC blank
+
+    def __init__(self, cfg: ModelConfig | None = None):
+        super().__init__()
+        if cfg is None:
+            cfg = ModelConfig()
+
+        channels = cfg.cnn_channels
+
+        self.cnn = nn.Sequential(
+            # Layer 1: 1 -> 32, pool 2x2
+            nn.Conv2d(1, channels[0], kernel_size=5, padding=2),
+            nn.BatchNorm2d(channels[0]),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(2, 2),
+            # Layer 2: 32 -> 64, pool 2x2
+            nn.Conv2d(channels[0], channels[1], kernel_size=5, padding=2),
+            nn.BatchNorm2d(channels[1]),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(2, 2),
+            # Layer 3: 64 -> 128, pool 1x2 (only pool width)
+            nn.Conv2d(channels[1], channels[2], kernel_size=3, padding=1),
+            nn.BatchNorm2d(channels[2]),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d((2, 2)),
+            # Layer 4: 128 -> 128, no pooling
+            nn.Conv2d(channels[2], channels[3], kernel_size=3, padding=1),
+            nn.BatchNorm2d(channels[3]),
+            nn.ReLU(inplace=True),
+            # Layer 5: 128 -> 256, pool 1x2 (only pool width)
+            nn.Conv2d(channels[3], channels[4], kernel_size=3, padding=1),
+            nn.BatchNorm2d(channels[4]),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d((2, 2)),
+        )
+
+        # After CNN: height = 32 / (2*2*2*2) = 2, width = 128 / (2*2*2*2) = 8
+        cnn_out_height = cfg.input_height // 16
+        rnn_input_size = channels[4] * cnn_out_height
+
+        self.rnn = nn.LSTM(
+            input_size=rnn_input_size,
+            hidden_size=cfg.rnn_hidden,
+            num_layers=cfg.rnn_layers,
+            bidirectional=True,
+            batch_first=True,
+            dropout=cfg.dropout if cfg.rnn_layers > 1 else 0.0,
+        )
+
+        self.fc = nn.Linear(cfg.rnn_hidden * 2, self.num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass.
+
+        Args:
+            x: (batch, 1, height, width) grayscale image tensor.
+
+        Returns:
+            (seq_len, batch, num_classes) log-probabilities for CTC.
+        """
+        features = self.cnn(x)  # (batch, channels, h', w')
+        batch, channels, h, w = features.shape
+        # Collapse height into channels, keep width as sequence dimension
+        features = features.permute(0, 3, 1, 2)  # (batch, w', channels, h')
+        features = features.reshape(batch, w, channels * h)  # (batch, w', channels*h')
+        rnn_out, _ = self.rnn(features)  # (batch, w', 2*hidden)
+        logits = self.fc(rnn_out)  # (batch, w', num_classes)
+        # CTC expects (seq_len, batch, num_classes)
+        return F.log_softmax(logits.permute(1, 0, 2), dim=2)
+
+
+def compute_ctc_loss(
+    log_probs: torch.Tensor,
+    targets: torch.Tensor,
+    target_lengths: torch.Tensor,
+) -> torch.Tensor:
+    input_lengths = torch.full(
+        (log_probs.size(1),), log_probs.size(0), dtype=torch.long
+    )
+    return F.ctc_loss(
+        log_probs, targets, input_lengths, target_lengths, blank=len(CHARSET)
+    )
+
+
+def greedy_decode(log_probs: torch.Tensor) -> list[str]:
+    """Best-path CTC decoding.
+
+    Args:
+        log_probs: (seq_len, batch, num_classes) from ``forward()``.
+
+    Returns:
+        List of decoded strings, one per batch element.
+    """
+    blank = len(CHARSET)
+    predictions = log_probs.argmax(dim=2).permute(1, 0)  # (batch, seq_len)
+    results = []
+    for pred in predictions:
+        chars = []
+        prev = blank
+        for idx in pred:
+            idx = idx.item()
+            if idx != prev and idx != blank:
+                chars.append(CHARSET[idx])
+            prev = idx
+        results.append("".join(chars))
+    return results

--- a/xournalpp_htr/training/simple_htr/network.py
+++ b/xournalpp_htr/training/simple_htr/network.py
@@ -46,10 +46,11 @@ class SimpleHTRNet(nn.Module):
             nn.BatchNorm2d(channels[2]),
             nn.ReLU(inplace=True),
             nn.MaxPool2d((2, 1)),
-            # Layer 4: 128 -> 128, no pooling
+            # Layer 4: 128 -> 128, pool height only (2x1)
             nn.Conv2d(channels[2], channels[3], kernel_size=3, padding=1),
             nn.BatchNorm2d(channels[3]),
             nn.ReLU(inplace=True),
+            nn.MaxPool2d((2, 1)),
             # Layer 5: 128 -> 256, pool height only (2x1)
             nn.Conv2d(channels[3], channels[4], kernel_size=3, padding=1),
             nn.BatchNorm2d(channels[4]),
@@ -57,8 +58,8 @@ class SimpleHTRNet(nn.Module):
             nn.MaxPool2d((2, 1)),
         )
 
-        # After CNN: height = 32 / (2*2*2*2) = 2, width = 128 / (2*2) = 32
-        cnn_out_height = cfg.input_height // 16
+        # After CNN: height = 32 / (2*2*2*2*2) = 1, width = 128 / (2*2) = 32
+        cnn_out_height = cfg.input_height // 32
         rnn_input_size = channels[4] * cnn_out_height
 
         self.rnn = nn.LSTM(

--- a/xournalpp_htr/training/simple_htr/network.py
+++ b/xournalpp_htr/training/simple_htr/network.py
@@ -40,23 +40,23 @@ class SimpleHTRNet(nn.Module):
             nn.BatchNorm2d(channels[1]),
             nn.ReLU(inplace=True),
             nn.MaxPool2d(2, 2),
-            # Layer 3: 64 -> 128, pool 1x2 (only pool width)
+            # Layer 3: 64 -> 128, pool height only (2x1)
             nn.Conv2d(channels[1], channels[2], kernel_size=3, padding=1),
             nn.BatchNorm2d(channels[2]),
             nn.ReLU(inplace=True),
-            nn.MaxPool2d((2, 2)),
+            nn.MaxPool2d((2, 1)),
             # Layer 4: 128 -> 128, no pooling
             nn.Conv2d(channels[2], channels[3], kernel_size=3, padding=1),
             nn.BatchNorm2d(channels[3]),
             nn.ReLU(inplace=True),
-            # Layer 5: 128 -> 256, pool 1x2 (only pool width)
+            # Layer 5: 128 -> 256, pool height only (2x1)
             nn.Conv2d(channels[3], channels[4], kernel_size=3, padding=1),
             nn.BatchNorm2d(channels[4]),
             nn.ReLU(inplace=True),
-            nn.MaxPool2d((2, 2)),
+            nn.MaxPool2d((2, 1)),
         )
 
-        # After CNN: height = 32 / (2*2*2*2) = 2, width = 128 / (2*2*2*2) = 8
+        # After CNN: height = 32 / (2*2*2*2) = 2, width = 128 / (2*2) = 32
         cnn_out_height = cfg.input_height // 16
         rnn_input_size = channels[4] * cnn_out_height
 

--- a/xournalpp_htr/training/simple_htr/run_training.eval.sh
+++ b/xournalpp_htr/training/simple_htr/run_training.eval.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_PATH=experiments
+
+best_cer=999
+best_dir=""
+
+for json_file in "${BASE_PATH}"/experiment1/*/best_model.json; do
+    [ -f "${json_file}" ] || continue
+    cer=$(python3 -c "import json; print(json.load(open('${json_file}'))['cer'])")
+    word_acc=$(python3 -c "import json; print(json.load(open('${json_file}'))['word_accuracy'])")
+    dir=$(dirname "${json_file}")
+    echo "${dir}: CER=${cer}, WordAcc=${word_acc}"
+    if python3 -c "exit(0 if ${cer} < ${best_cer} else 1)"; then
+        best_cer="${cer}"
+        best_dir="${dir}"
+    fi
+done
+
+echo
+echo "Best model: ${best_dir}/best_model.pth (CER=${best_cer})"

--- a/xournalpp_htr/training/simple_htr/run_training.sh
+++ b/xournalpp_htr/training/simple_htr/run_training.sh
@@ -39,17 +39,78 @@ experiment1() {
     done
 }
 
+# ============
+# Experiment 2
+# ============
+
+# Question: Does augmentation help?
+# Uses best LR from experiment 1 (0.0005), sweeps batch size with augmentation
+# on vs off. Longer training (200 epochs) to let augmented runs converge.
+
+experiment2() {
+    local EPOCH_MAX=200
+    local LEARNING_RATE=0.0005
+
+    for AUGMENTATION in false true
+    do
+        for BATCH_SIZE in 32 64 128
+        do
+
+            echo "AUG=${AUGMENTATION}, BS=${BATCH_SIZE}"
+
+            OUT="${BASE_PATH}/experiment2/aug${AUGMENTATION}_bs${BATCH_SIZE}"
+            mkdir -p "${OUT}"
+
+            time uv run python -m xournalpp_htr.training.simple_htr.train \
+                training.learning_rate="${LEARNING_RATE}" \
+                training.batch_size="${BATCH_SIZE}" \
+                augmentation.enabled="${AUGMENTATION}" \
+                output_path="${OUT}" \
+                training.epoch_max="${EPOCH_MAX}" 2>&1 | tee "${OUT}/train.log"
+
+        done
+    done
+}
+
+# ============
+# Experiment 3
+# ============
+
+# Question: Does dropout help?
+# Uses best LR from experiment 1 (0.0005) and best augmentation setting from
+# experiment 2. Sweeps dropout rates.
+
+experiment3() {
+    local EPOCH_MAX=200
+    local LEARNING_RATE=0.0005
+    local BATCH_SIZE=64
+
+    for DROPOUT in 0.0 0.2 0.5
+    do
+        for AUGMENTATION in false true
+        do
+
+            echo "DO=${DROPOUT}, AUG=${AUGMENTATION}"
+
+            OUT="${BASE_PATH}/experiment3/do${DROPOUT}_aug${AUGMENTATION}"
+            mkdir -p "${OUT}"
+
+            time uv run python -m xournalpp_htr.training.simple_htr.train \
+                training.learning_rate="${LEARNING_RATE}" \
+                training.batch_size="${BATCH_SIZE}" \
+                model.dropout="${DROPOUT}" \
+                augmentation.enabled="${AUGMENTATION}" \
+                output_path="${OUT}" \
+                training.epoch_max="${EPOCH_MAX}" 2>&1 | tee "${OUT}/train.log"
+
+        done
+    done
+}
+
 # ==================
 # Run experiments
 # ==================
 
-time experiment1
-
-# ==================
-# Future experiments
-# ==================
-
-# Other questions to answer by conducting additional experiments:
-# - Does augmentation help?
-# - Longer training with more patience?
-# - Effect of dropout?
+# time experiment1
+time experiment2
+time experiment3

--- a/xournalpp_htr/training/simple_htr/run_training.sh
+++ b/xournalpp_htr/training/simple_htr/run_training.sh
@@ -43,7 +43,7 @@ experiment1() {
 # Run experiments
 # ==================
 
-experiment1
+time experiment1
 
 # ==================
 # Future experiments

--- a/xournalpp_htr/training/simple_htr/run_training.sh
+++ b/xournalpp_htr/training/simple_htr/run_training.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# `pipefail` is required so a failed training run still aborts the script even
+# though its output is piped into `tee` for logging.
+set -euo pipefail
+
+# ========
+# Settings
+# ========
+
+BASE_PATH=experiments
+
+# ============
+# Experiment 1
+# ============
+
+# Question: General hyperparameter tuning (learning rate and batch size)
+
+experiment1() {
+    local EPOCH_MAX=100
+
+    for LEARNING_RATE in 0.0005 0.001 0.002
+    do
+        for BATCH_SIZE in 32 64 128
+        do
+
+            echo "LR=${LEARNING_RATE}, BS=${BATCH_SIZE}"
+
+            OUT="${BASE_PATH}/experiment1/lr${LEARNING_RATE}_bs${BATCH_SIZE}"
+            mkdir -p "${OUT}"
+
+            time uv run python -m xournalpp_htr.training.simple_htr.train \
+                training.learning_rate="${LEARNING_RATE}" \
+                training.batch_size="${BATCH_SIZE}" \
+                output_path="${OUT}" \
+                training.epoch_max="${EPOCH_MAX}" 2>&1 | tee "${OUT}/train.log"
+
+        done
+    done
+}
+
+# ==================
+# Run experiments
+# ==================
+
+experiment1
+
+# ==================
+# Future experiments
+# ==================
+
+# Other questions to answer by conducting additional experiments:
+# - Does augmentation help?
+# - Longer training with more patience?
+# - Effect of dropout?

--- a/xournalpp_htr/training/simple_htr/test_best_model.ipynb
+++ b/xournalpp_htr/training/simple_htr/test_best_model.ipynb
@@ -1,0 +1,228 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Test the best obtained SimpleHTR model\n",
+    "\n",
+    "Inspect a trained `best_model.pth` checkpoint end-to-end, **fully offline**:\n",
+    "\n",
+    "1. Export the checkpoint to the ONNX inference artifact + `config.json` (ADR 006).\n",
+    "2. Build a `SimpleHTRModel` from the *local* files (no HF Hub needed).\n",
+    "3. Run recognition on IAM word images and compare PyTorch vs ONNX outputs.\n",
+    "4. Assert numerical equivalence of log-probabilities.\n",
+    "\n",
+    "Requires the `training-simple-htr` extra. Run from the repo root with\n",
+    "`uv run jupyter lab`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import onnxruntime as ort\n",
+    "\n",
+    "from xournalpp_htr.inference_models import SimpleHTRModel\n",
+    "from xournalpp_htr.training.simple_htr.dataset import IAM_Words_Dataset\n",
+    "from xournalpp_htr.training.simple_htr.export import export\n",
+    "from xournalpp_htr.training.simple_htr.infer import run_image_through_network\n",
+    "\n",
+    "CHECKPOINT = Path(\"experiments/experiment3/do0.5_augtrue/best_model.pth\")\n",
+    "EXPORT_DIR = Path(\"exports\")\n",
+    "assert CHECKPOINT.exists(), f\"No checkpoint at {CHECKPOINT.resolve()}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "section1-header",
+   "metadata": {},
+   "source": [
+    "## 1. Export checkpoint → ONNX + config.json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "export",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "paths = export(CHECKPOINT, EXPORT_DIR)\n",
+    "paths"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "section2-header",
+   "metadata": {},
+   "source": [
+    "## 2. Build a SimpleHTRModel from the local export\n",
+    "\n",
+    "`from_pretrained` would fetch from HF Hub; here we construct the same object\n",
+    "directly from the local ONNX + config so the notebook stays offline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "build-model",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(paths[\"config\"]) as f:\n",
+    "    config = json.load(f)\n",
+    "\n",
+    "model = SimpleHTRModel(\n",
+    "    session=ort.InferenceSession(str(paths[\"onnx\"])),\n",
+    "    config=config,\n",
+    "    revision=\"local\",\n",
+    ")\n",
+    "model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "section3-header",
+   "metadata": {},
+   "source": [
+    "## 3. Load IAM test images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "load-images",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = IAM_Words_Dataset(\n",
+    "    target_height=config[\"input_size\"][\"height\"],\n",
+    "    target_width=config[\"input_size\"][\"width\"],\n",
+    "    augment=False,\n",
+    ")\n",
+    "\n",
+    "SAMPLE_INDICES = [0, 100, 500, 1000, 5000]\n",
+    "samples = [(dataset.img_cache[i], dataset.text_cache[i]) for i in SAMPLE_INDICES]\n",
+    "print(f\"Loaded {len(samples)} samples: {[s[1] for s in samples]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "section4-header",
+   "metadata": {},
+   "source": [
+    "## 4. PyTorch vs ONNX comparison\n",
+    "\n",
+    "For each sample, run both inference paths and compare decoded text and raw\n",
+    "log-probabilities."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "compare",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session = ort.InferenceSession(str(paths[\"onnx\"]))\n",
+    "input_name = session.get_inputs()[0].name\n",
+    "charset = config[\"charset\"]\n",
+    "norm = config[\"normalization\"]\n",
+    "\n",
+    "all_max_diffs = []\n",
+    "\n",
+    "for img_raw, gt_text in samples:\n",
+    "    # PyTorch path\n",
+    "    torch_result = run_image_through_network(\n",
+    "        img_raw, model_path=CHECKPOINT, device=\"cpu\"\n",
+    "    )\n",
+    "    torch_text = torch_result[\"text\"]\n",
+    "    torch_log_probs = torch_result[\"log_probs\"]  # (seq_len, num_classes)\n",
+    "\n",
+    "    # ONNX path — run session directly to get raw log_probs\n",
+    "    preprocessed = torch_result[\"model_input_image\"]  # reuse same preprocessing\n",
+    "    net_input = preprocessed[None, None, :, :].astype(np.float32)\n",
+    "    onnx_log_probs = session.run(None, {input_name: net_input})[0][:, 0, :]\n",
+    "\n",
+    "    # ONNX text via SimpleHTRModel\n",
+    "    onnx_text = model.recognize(img_raw)\n",
+    "\n",
+    "    # Numerical comparison\n",
+    "    max_diff = np.max(np.abs(torch_log_probs - onnx_log_probs))\n",
+    "    mean_diff = np.mean(np.abs(torch_log_probs - onnx_log_probs))\n",
+    "    all_max_diffs.append(max_diff)\n",
+    "    text_match = torch_text == onnx_text\n",
+    "\n",
+    "    # Visualise\n",
+    "    fig, axes = plt.subplots(1, 3, figsize=(18, 3))\n",
+    "    axes[0].imshow(img_raw, cmap=\"gray\")\n",
+    "    axes[0].set_title(f\"Input (GT: '{gt_text}')\")\n",
+    "    axes[0].axis(\"off\")\n",
+    "    axes[1].imshow(torch_log_probs.T, aspect=\"auto\", cmap=\"Blues\")\n",
+    "    axes[1].set_title(f\"PyTorch: '{torch_text}'\")\n",
+    "    axes[1].set_xlabel(\"Timestep\")\n",
+    "    axes[2].imshow(onnx_log_probs.T, aspect=\"auto\", cmap=\"Blues\")\n",
+    "    axes[2].set_title(f\"ONNX: '{onnx_text}'\")\n",
+    "    axes[2].set_xlabel(\"Timestep\")\n",
+    "    fig.suptitle(\n",
+    "        f\"max diff: {max_diff:.2e}, mean diff: {mean_diff:.2e}, \"\n",
+    "        f\"text match: {text_match}\",\n",
+    "        fontsize=11,\n",
+    "    )\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "\n",
+    "    assert text_match, f\"Text mismatch: PyTorch='{torch_text}' vs ONNX='{onnx_text}'\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "section5-header",
+   "metadata": {},
+   "source": [
+    "## 5. Summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "summary",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "overall_max_diff = max(all_max_diffs)\n",
+    "print(f\"Samples tested: {len(samples)}\")\n",
+    "print(f\"Overall max |PyTorch - ONNX|: {overall_max_diff:.2e}\")\n",
+    "print(\"All texts matched: True\")\n",
+    "\n",
+    "assert np.allclose(\n",
+    "    torch_log_probs, onnx_log_probs, atol=1e-5\n",
+    "), f\"Log-probs differ by more than 1e-5 (max: {overall_max_diff:.2e})\"\n",
+    "print(\"\\nONNX export validated successfully.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/xournalpp_htr/training/simple_htr/train.py
+++ b/xournalpp_htr/training/simple_htr/train.py
@@ -33,7 +33,6 @@ from xournalpp_htr.training.simple_htr.utils import (
     get_device,
     get_git_commit_hash,
 )
-from xournalpp_htr.xio import load_IAM_DB_dataset
 
 cs = ConfigStore.instance()
 cs.store(name="simple_htr", node=SimpleHTRConfig)
@@ -71,7 +70,7 @@ def compute_cer(predicted: str, target: str) -> float:
 
 
 def get_dataloaders(
-    data_path: Path,
+    data_path: Path | None,
     percent_train_data: int,
     batch_size: int,
     shuffle_data_loader: bool,
@@ -83,17 +82,17 @@ def get_dataloaders(
     augment: bool = False,
 ) -> dict:
     train_dataset = IAM_Words_Dataset(
-        root_dir=data_path,
         target_height=target_height,
         target_width=target_width,
+        root_dir=data_path,
         force_rebuild_cache=False,
         augment=augment,
         cache_path=cache_path,
     )
     val_dataset = IAM_Words_Dataset(
-        root_dir=data_path,
         target_height=target_height,
         target_width=target_width,
+        root_dir=data_path,
         force_rebuild_cache=False,
         augment=False,
         cache_path=cache_path,
@@ -265,10 +264,6 @@ def main(cfg: SimpleHTRConfig):
 
     data_path = Path(cfg.data.data_path) if cfg.data.data_path else None
     cache_path = Path(cfg.data.cache_path)
-
-    if data_path is None:
-        data_path = load_IAM_DB_dataset()
-        print(f"Resolved IAM-DB dataset from HuggingFace Hub: {data_path}")
 
     output_path.mkdir(exist_ok=True, parents=True)
 

--- a/xournalpp_htr/training/simple_htr/train.py
+++ b/xournalpp_htr/training/simple_htr/train.py
@@ -130,15 +130,20 @@ def get_dataloaders(
         pin_memory=True,
     )
 
-    return {"train": dataloader_train, "val": dataloader_val}
+    return {
+        "train": dataloader_train,
+        "val": dataloader_val,
+        "charset": train_dataset.charset,
+    }
 
 
-def validate(net, dataloader_val, writer, device, global_step):
+def validate(net, dataloader_val, writer, device, global_step, charset):
     net.eval()
     total_loss = 0.0
     total_cer = 0.0
     total_correct = 0
     total_samples = 0
+    blank = len(charset)
 
     for batch in dataloader_val:
         images = batch["images"].to(device)
@@ -148,10 +153,10 @@ def validate(net, dataloader_val, writer, device, global_step):
 
         with torch.no_grad():
             log_probs = net(images)
-            loss = compute_ctc_loss(log_probs, targets, target_lengths)
+            loss = compute_ctc_loss(log_probs, targets, target_lengths, blank)
             total_loss += loss.item()
 
-            decoded = greedy_decode(log_probs)
+            decoded = greedy_decode(log_probs, charset)
             for pred, gt in zip(decoded, texts, strict=False):
                 total_cer += compute_cer(pred, gt)
                 if pred == gt:
@@ -169,8 +174,9 @@ def validate(net, dataloader_val, writer, device, global_step):
     return avg_cer, word_acc
 
 
-def train_epoch(net, optimizer, loader, writer, device, global_step):
+def train_epoch(net, optimizer, loader, writer, device, global_step, charset):
     net.train()
+    blank = len(charset)
     for i, batch in enumerate(loader):
         images = batch["images"].to(device)
         targets = batch["targets"].to(device)
@@ -178,7 +184,7 @@ def train_epoch(net, optimizer, loader, writer, device, global_step):
 
         optimizer.zero_grad()
         log_probs = net(images)
-        loss = compute_ctc_loss(log_probs, targets, target_lengths)
+        loss = compute_ctc_loss(log_probs, targets, target_lengths, blank)
         loss.backward()
         torch.nn.utils.clip_grad_norm_(net.parameters(), max_norm=5.0)
         optimizer.step()
@@ -195,11 +201,16 @@ def train_network(
     cfg: SimpleHTRConfig,
     dataloader_train,
     dataloader_val,
+    charset: list[str],
 ):
     writer = SummaryWriter(output_path / "summary_writer")
 
-    net = SimpleHTRNet()
+    num_classes = len(charset) + 1  # +1 for CTC blank
+    net = SimpleHTRNet(num_classes=num_classes)
     net.to(device)
+
+    with open(output_path / "charset.json", "w") as f:
+        json.dump(charset, f)
 
     optimizer = torch.optim.Adam(net.parameters(), lr=cfg.training.learning_rate)
 
@@ -211,10 +222,12 @@ def train_network(
         epoch += 1
         print(f"Epoch: {epoch}")
         global_step = train_epoch(
-            net, optimizer, dataloader_train, writer, device, global_step
+            net, optimizer, dataloader_train, writer, device, global_step, charset
         )
         if epoch % cfg.training.val_epoch == 0:
-            cer, word_acc = validate(net, dataloader_val, writer, device, global_step)
+            cer, word_acc = validate(
+                net, dataloader_val, writer, device, global_step, charset
+            )
             print(f"  Val CER: {cer:.4f}, Word Accuracy: {word_acc:.4f}")
 
             if cer < best_val_cer:
@@ -293,6 +306,9 @@ def main(cfg: SimpleHTRConfig):
     )
     dataloaders_time = time.time() - t0
 
+    charset = dataloaders["charset"]
+    print(f"Charset: {len(charset)} characters")
+
     t0 = time.time()
     train_network(
         output_path=output_path,
@@ -300,6 +316,7 @@ def main(cfg: SimpleHTRConfig):
         cfg=cfg,
         dataloader_train=dataloaders["train"],
         dataloader_val=dataloaders["val"],
+        charset=charset,
     )
     training_time = time.time() - t0
 

--- a/xournalpp_htr/training/simple_htr/train.py
+++ b/xournalpp_htr/training/simple_htr/train.py
@@ -1,0 +1,326 @@
+"""SimpleHTR training entrypoint.
+
+Requires the ``training-simple-htr`` extra. Run with::
+
+    uv run python -m xournalpp_htr.training.simple_htr.train --help
+"""
+
+import json
+import random
+import time
+from pathlib import Path
+
+import hydra
+import numpy as np
+import torch
+from hydra.core.config_store import ConfigStore
+from omegaconf import OmegaConf
+from torch.utils.data import DataLoader, Subset
+from torch.utils.tensorboard import SummaryWriter
+
+from xournalpp_htr.training.simple_htr.config import SimpleHTRConfig
+from xournalpp_htr.training.simple_htr.dataset import (
+    IAM_Words_Dataset,
+    custom_collate_fn,
+)
+from xournalpp_htr.training.simple_htr.network import (
+    SimpleHTRNet,
+    compute_ctc_loss,
+    greedy_decode,
+)
+from xournalpp_htr.training.simple_htr.utils import (
+    CustomEncoder,
+    get_device,
+    get_git_commit_hash,
+)
+from xournalpp_htr.xio import load_IAM_DB_dataset
+
+cs = ConfigStore.instance()
+cs.store(name="simple_htr", node=SimpleHTRConfig)
+
+
+def seed_everything(numpy_seed=42, torch_seed=1234, random_seed=7):
+    random.seed(random_seed)
+    np.random.seed(numpy_seed)
+    torch.manual_seed(torch_seed)
+    torch.cuda.manual_seed(torch_seed)
+    torch.cuda.manual_seed_all(torch_seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+    print(
+        f"Seeds set -> random: {random_seed}, numpy: {numpy_seed}, torch: {torch_seed}"
+    )
+
+
+def compute_cer(predicted: str, target: str) -> float:
+    """Character Error Rate via edit distance."""
+    if len(target) == 0:
+        return 0.0 if len(predicted) == 0 else 1.0
+
+    d = np.zeros((len(predicted) + 1, len(target) + 1), dtype=np.int32)
+    for i in range(len(predicted) + 1):
+        d[i, 0] = i
+    for j in range(len(target) + 1):
+        d[0, j] = j
+    for i in range(1, len(predicted) + 1):
+        for j in range(1, len(target) + 1):
+            cost = 0 if predicted[i - 1] == target[j - 1] else 1
+            d[i, j] = min(d[i - 1, j] + 1, d[i, j - 1] + 1, d[i - 1, j - 1] + cost)
+
+    return d[len(predicted), len(target)] / len(target)
+
+
+def get_dataloaders(
+    data_path: Path,
+    percent_train_data: int,
+    batch_size: int,
+    shuffle_data_loader: bool,
+    num_workers: int,
+    output_path: Path,
+    cache_path: Path,
+    target_height: int,
+    target_width: int,
+    augment: bool = False,
+) -> dict:
+    train_dataset = IAM_Words_Dataset(
+        root_dir=data_path,
+        target_height=target_height,
+        target_width=target_width,
+        force_rebuild_cache=False,
+        augment=augment,
+        cache_path=cache_path,
+    )
+    val_dataset = IAM_Words_Dataset(
+        root_dir=data_path,
+        target_height=target_height,
+        target_width=target_width,
+        force_rebuild_cache=False,
+        augment=False,
+        cache_path=cache_path,
+    )
+
+    assert len(train_dataset) == len(val_dataset)
+
+    indices = list(range(len(train_dataset)))
+    np.random.shuffle(indices)
+    split = int(percent_train_data / 100 * len(indices))
+
+    train_indices = indices[:split]
+    val_indices = indices[split:]
+
+    with open(output_path / "dataset_split_indices.json", "w") as f:
+        json.dump({"train": train_indices, "val": val_indices}, f, indent=4)
+
+    train_subset = Subset(train_dataset, train_indices)
+    val_subset = Subset(val_dataset, val_indices)
+
+    dataloader_train = DataLoader(
+        train_subset,
+        batch_size=batch_size,
+        shuffle=shuffle_data_loader,
+        num_workers=num_workers,
+        collate_fn=custom_collate_fn,
+        pin_memory=True,
+    )
+    dataloader_val = DataLoader(
+        val_subset,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        collate_fn=custom_collate_fn,
+        pin_memory=True,
+    )
+
+    return {"train": dataloader_train, "val": dataloader_val}
+
+
+def validate(net, dataloader_val, writer, device, global_step):
+    net.eval()
+    total_loss = 0.0
+    total_cer = 0.0
+    total_correct = 0
+    total_samples = 0
+
+    for batch in dataloader_val:
+        images = batch["images"].to(device)
+        targets = batch["targets"].to(device)
+        target_lengths = batch["target_lengths"].to(device)
+        texts = batch["texts"]
+
+        with torch.no_grad():
+            log_probs = net(images)
+            loss = compute_ctc_loss(log_probs, targets, target_lengths)
+            total_loss += loss.item()
+
+            decoded = greedy_decode(log_probs)
+            for pred, gt in zip(decoded, texts, strict=False):
+                total_cer += compute_cer(pred, gt)
+                if pred == gt:
+                    total_correct += 1
+                total_samples += 1
+
+    avg_loss = total_loss / len(dataloader_val)
+    avg_cer = total_cer / max(total_samples, 1)
+    word_acc = total_correct / max(total_samples, 1)
+
+    writer.add_scalar("loss/val", avg_loss, global_step)
+    writer.add_scalar("cer/val", avg_cer, global_step)
+    writer.add_scalar("word_accuracy/val", word_acc, global_step)
+
+    return avg_cer, word_acc
+
+
+def train_epoch(net, optimizer, loader, writer, device, global_step):
+    net.train()
+    for i, batch in enumerate(loader):
+        images = batch["images"].to(device)
+        targets = batch["targets"].to(device)
+        target_lengths = batch["target_lengths"].to(device)
+
+        optimizer.zero_grad()
+        log_probs = net(images)
+        loss = compute_ctc_loss(log_probs, targets, target_lengths)
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(net.parameters(), max_norm=5.0)
+        optimizer.step()
+
+        print(f"{i + 1}/{len(loader)}: {loss.item():.4f}")
+        writer.add_scalar("loss/train", loss.item(), global_step)
+        global_step += 1
+    return global_step
+
+
+def train_network(
+    output_path: Path,
+    device: str,
+    cfg: SimpleHTRConfig,
+    dataloader_train,
+    dataloader_val,
+):
+    writer = SummaryWriter(output_path / "summary_writer")
+
+    net = SimpleHTRNet()
+    net.to(device)
+
+    optimizer = torch.optim.Adam(net.parameters(), lr=cfg.training.learning_rate)
+
+    global_step = 0
+    epoch = 0
+    best_val_cer = float("inf")
+    patience_counter = 0
+    while True:
+        epoch += 1
+        print(f"Epoch: {epoch}")
+        global_step = train_epoch(
+            net, optimizer, dataloader_train, writer, device, global_step
+        )
+        if epoch % cfg.training.val_epoch == 0:
+            cer, word_acc = validate(net, dataloader_val, writer, device, global_step)
+            print(f"  Val CER: {cer:.4f}, Word Accuracy: {word_acc:.4f}")
+
+            if cer < best_val_cer:
+                print(f"New best CER: {best_val_cer:.4f} -> {cer:.4f}, saving model.")
+                best_val_cer = cer
+                torch.save(net.state_dict(), output_path / "best_model.pth")
+                patience_counter = 0
+                with open(output_path / "best_model.json", "w") as f:
+                    json.dump(
+                        {
+                            "epoch": epoch,
+                            "global_step": global_step,
+                            "cer": best_val_cer,
+                            "word_accuracy": word_acc,
+                        },
+                        f,
+                        indent=4,
+                    )
+            else:
+                patience_counter += 1
+
+        if patience_counter >= cfg.training.patience_max:
+            print("Early stopping triggered.")
+            break
+
+        if epoch >= cfg.training.epoch_max:
+            print(f"Reached max epoch {cfg.training.epoch_max}, stopping training.")
+            break
+
+    writer.add_hparams(
+        {
+            "learning_rate": cfg.training.learning_rate,
+            "batch_size": cfg.training.batch_size,
+            "seed_split": cfg.seed.split,
+            "seed_model": cfg.seed.model,
+            "patience_max": cfg.training.patience_max,
+            "augmentation_enabled": cfg.augmentation.enabled,
+        },
+        {"best_val_cer": best_val_cer},
+    )
+    writer.close()
+
+
+@hydra.main(version_base=None, config_name="simple_htr")
+def main(cfg: SimpleHTRConfig):
+    output_path = Path(cfg.output_path)
+
+    data_path = Path(cfg.data.data_path) if cfg.data.data_path else None
+    cache_path = Path(cfg.data.cache_path)
+
+    if data_path is None and not cache_path.exists():
+        data_path = load_IAM_DB_dataset()
+        print(f"Resolved IAM-DB dataset from HuggingFace Hub: {data_path}")
+
+    output_path.mkdir(exist_ok=True, parents=True)
+
+    with open(output_path / "config.yaml", "w") as f:
+        f.write(OmegaConf.to_yaml(cfg))
+
+    device = get_device()
+
+    seed_everything(
+        numpy_seed=cfg.seed.split,
+        torch_seed=cfg.seed.model,
+        random_seed=cfg.seed.model,
+    )
+
+    t0 = time.time()
+    dataloaders = get_dataloaders(
+        data_path=data_path,
+        percent_train_data=cfg.data.percent_train_data,
+        batch_size=cfg.training.batch_size,
+        shuffle_data_loader=cfg.data.shuffle_data_loader,
+        num_workers=cfg.training.num_workers,
+        output_path=output_path,
+        cache_path=cache_path,
+        target_height=cfg.model.input_height,
+        target_width=cfg.model.input_width,
+        augment=cfg.augmentation.enabled,
+    )
+    dataloaders_time = time.time() - t0
+
+    t0 = time.time()
+    train_network(
+        output_path=output_path,
+        device=device,
+        cfg=cfg,
+        dataloader_train=dataloaders["train"],
+        dataloader_val=dataloaders["val"],
+    )
+    training_time = time.time() - t0
+
+    with open(output_path / "git_commit_hash.json", "w") as f:
+        json.dump(
+            {"git_commit_hash": get_git_commit_hash()}, f, indent=4, cls=CustomEncoder
+        )
+
+    with open(output_path / "times.json", "w") as f:
+        json.dump(
+            {"dataloaders": dataloaders_time, "training": training_time},
+            f,
+            indent=4,
+            cls=CustomEncoder,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/xournalpp_htr/training/simple_htr/train.py
+++ b/xournalpp_htr/training/simple_htr/train.py
@@ -263,6 +263,8 @@ def train_network(
             "batch_size": cfg.training.batch_size,
             "seed_split": cfg.seed.split,
             "seed_model": cfg.seed.model,
+            "dropout": cfg.model.dropout,
+            "epoch_max": cfg.training.epoch_max,
             "patience_max": cfg.training.patience_max,
             "augmentation_enabled": cfg.augmentation.enabled,
         },

--- a/xournalpp_htr/training/simple_htr/train.py
+++ b/xournalpp_htr/training/simple_htr/train.py
@@ -266,7 +266,7 @@ def main(cfg: SimpleHTRConfig):
     data_path = Path(cfg.data.data_path) if cfg.data.data_path else None
     cache_path = Path(cfg.data.cache_path)
 
-    if data_path is None and not cache_path.exists():
+    if data_path is None:
         data_path = load_IAM_DB_dataset()
         print(f"Resolved IAM-DB dataset from HuggingFace Hub: {data_path}")
 

--- a/xournalpp_htr/training/simple_htr/train.py
+++ b/xournalpp_htr/training/simple_htr/train.py
@@ -206,7 +206,7 @@ def train_network(
     writer = SummaryWriter(output_path / "summary_writer")
 
     num_classes = len(charset) + 1  # +1 for CTC blank
-    net = SimpleHTRNet(num_classes=num_classes)
+    net = SimpleHTRNet(num_classes=num_classes, cfg=cfg.model)
     net.to(device)
 
     with open(output_path / "charset.json", "w") as f:

--- a/xournalpp_htr/training/simple_htr/utils.py
+++ b/xournalpp_htr/training/simple_htr/utils.py
@@ -1,0 +1,38 @@
+"""Small helpers for SimpleHTR training and the local demo.
+
+Git-hash capture, a JSON encoder for ``Path``, and device selection.
+Per ADR 007 the model ships a local-only demo with no HuggingFace Space.
+"""
+
+import json
+from pathlib import Path
+
+import torch
+from git import Repo
+
+
+def get_device(preference: str = "auto") -> str:
+    """Resolve a device string, with auto-detection for ``"auto"``."""
+    if preference == "auto":
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    return preference
+
+
+class CustomEncoder(json.JSONEncoder):
+    """Make non-standard items serialisable for ``json.dump(s)``."""
+
+    def default(self, obj):
+        if isinstance(obj, Path):
+            return str(obj)
+        return super().default(obj)
+
+
+def get_git_commit_hash(repo_path: Path = Path("."), short: bool = False) -> str:
+    """Return the current Git commit hash, or ``"-1"`` if unavailable."""
+    try:
+        repo = Repo(repo_path, search_parent_directories=True)
+        commit_hash: str = repo.head.commit.hexsha
+        return commit_hash[:7] if short else commit_hash
+    except Exception as e:
+        print(f"Error while getting git commit hash from {repo_path}: {e}")
+        return "-1"


### PR DESCRIPTION
## Summary

Closes #101.

- Implement the SimpleHTR model — a reimplementation of [Harald Scheidl's SimpleHTR](https://github.com/githubharald/SimpleHTR) with 5 CNN layers, 2 bidirectional LSTM layers, and CTC output for handwritten word recognition
- Add full training pipeline: Hydra config, IAM dataset loader, training script with TensorBoard logging, hyperparameter sweep shell script, and evaluation
- Add ONNX export with HuggingFace Hub upload, local inference script, and Gradio demo
- Document three training experiments (baseline, augmentation, dropout) with results in `docs/models/simple_htr.md`
- Register the model in the inference pipeline (`inference_models.py`) with tests

## Files

| Area | Files |
|------|-------|
| Model | `network.py`, `config.py`, `__init__.py` |
| Data | `dataset.py` |
| Training | `train.py`, `run_training.sh`, `run_training.eval.sh`, `utils.py` |
| Inference | `infer.py`, `export.py`, `demo.py`, `test_best_model.ipynb` |
| Integration | `inference_models.py`, `test_inference_models.py`, `pyproject.toml` |
| Docs | `simple_htr.md`, `docs/models/index.md` |

## Test plan

- [x] Training runs complete on A100 GPU with expected CER (~8%)
- [x] ONNX export and validation notebook pass
- [x] Gradio demo runs locally with draw and image-upload tabs
- [ ] `make tests-not-slow` passes