### PR TITLE
Add SimpleHTR model docs to mkdocs nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
   - Models:
     - Overview: 'models/index.md'
     - WordDetector: 'models/word_detector.md'
+    - SimpleHTR: 'models/simple_htr.md'
   - Contributing: 'contributing.md'
   - Issue Labels: 'labels.md'
   - Roadmap: 'roadmap.md'


### PR DESCRIPTION
## Summary
- Add `simple_htr.md` to the Models section in mkdocs navigation

Closes #123