### PR TITLE
Build end-to-end HTR pipeline with WordDetectorNet and SimpleHTR

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,10 +76,10 @@ graph TD
 
 2. **Render pages** -- Each page is rendered to a 150 DPI grayscale image via matplotlib using the stroke coordinates.
 
-3. **Run HTR** -- The external `htr_pipeline` library processes each image:
-    - **Word detection** -- An ONNX model locates word regions (scaled to 40%, with 5px margin).
-    - **Line clustering** -- DBSCAN groups detected words into lines (discarding lines with fewer than 2 words).
-    - **Text recognition** -- A second ONNX model recognises each word via CTC decoding.
+3. **Run HTR** -- `compute_predictions()` dispatches on the `--pipeline` argument to one of two implementations:
+
+    - `2024-07-18_htr_pipeline` (default) -- The external `htr_pipeline` library processes each image: an ONNX word detector locates regions (scaled to 40%, 5px margin), DBSCAN groups detections into lines (discarding lines with fewer than 2 words), and a second ONNX model recognises each word via CTC decoding.
+    - `2025-06-07_local_pipeline` -- An in-house pipeline that loads our locally-trained ONNX models from HuggingFace Hub (`WordDetectorModel` + `SimpleHTRModel`, see `xournalpp_htr/inference_models.py`) and runs detection + per-word recognition without `htr_pipeline`. Replacing the external dependency entirely is tracked in #125.
 
     Output is a dictionary mapping page indices to lists of predictions (text + bounding box coordinates in image pixels).
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -72,6 +72,7 @@ To benchmark a specific pipeline or change the output format:
 
 ```bash
 uv run python scripts/run_benchmark.py --pipeline 2024-07-18_htr_pipeline
+uv run python scripts/run_benchmark.py --pipeline 2025-06-07_local_pipeline
 uv run python scripts/run_benchmark.py --format json
 ```
 

--- a/docs/models/simple_htr.md
+++ b/docs/models/simple_htr.md
@@ -213,8 +213,8 @@ print(text)
 - [x] Hyperparameter sweep script
 - [x] First training run and experiment log
 - [x] ONNX validation notebook
+- [x] Integrated into end-to-end pipeline with WordDetectorNet (`2025-06-07_local_pipeline`, issue #121)
 
 ## Outlook
 
 - Add beam search decoding (issue #120)
-- Integrate into full pipeline (word detection + recognition)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,11 +22,12 @@ this setup will likely become the preferred installation method in the future.
 
 Additionally, we currently rely on a third-party library called `htr_pipeline` for model delivery.
 While effective, it complicates installation and model management. We plan to replace it with an
-in-house implementation. The first component, the WordDetectorNet, has already been internalized
+in-house implementation. Both components have now been internalized: the WordDetectorNet
 (see [explanation of model](https://lellep.xyz/blog/worddetectornet-visually-explained.html),
 [code](https://github.com/PellelNitram/xournalpp_htr/tree/master/xournalpp_htr/training/WordDetectorNN) and
-[demo](https://huggingface.co/spaces/PellelNitram/xournalpp_htr_WordDetectorNN)).
-This transition away from `htr_pipeline` will not be backward compatible.
+[demo](https://huggingface.co/spaces/PellelNitram/xournalpp_htr_WordDetectorNN)) and SimpleHTR, which
+are wired together into the `2025-06-07_local_pipeline` (issue #121). Fully removing the `htr_pipeline`
+dependency is tracked in #125. This transition away from `htr_pipeline` will not be backward compatible.
 
 ## Roadmap as of *2025-05-03*
 

--- a/tests/test_run_htr.py
+++ b/tests/test_run_htr.py
@@ -62,3 +62,19 @@ def test_main(get_path_to_minimal_test_data: Path, tmp_path: Path) -> None:
     }
 
     export_xournalpp_to_pdf_with_htr(args)
+
+
+@pytest.mark.slow
+def test_main_local_pipeline(
+    get_path_to_minimal_test_data: Path, tmp_path: Path
+) -> None:
+    args = {
+        "input_file": get_path_to_minimal_test_data,
+        "output_file": tmp_path / Path("test_main_local.pdf"),
+        "pipeline": "2025-06-07_local_pipeline",
+        "prediction_image_dir": None,
+        "show_predictions": False,
+        "small_text": False,
+    }
+
+    export_xournalpp_to_pdf_with_htr(args)

--- a/xournalpp_htr/models.py
+++ b/xournalpp_htr/models.py
@@ -10,6 +10,8 @@ import matplotlib.pyplot as plt
 from htr_pipeline import DetectorConfig, LineClusteringConfig, read_page
 from tqdm import tqdm
 
+from xournalpp_htr.inference_models import SimpleHTRModel, WordDetectorModel
+
 PageIndex = int
 
 
@@ -92,6 +94,63 @@ def compute_predictions(
                                 ymax=word.aabb.ymax * coord_scale,
                             )
                         )
+                predictions[page_index] = predictions_page
+
+    elif pipeline_name == "2025-06-07_local_pipeline":
+        RENDER_DPI = 150
+        nr_pages = len(document.pages)
+
+        detector = WordDetectorModel.from_pretrained()
+        recognizer = SimpleHTRModel.from_pretrained()
+
+        for page_index in tqdm(range(nr_pages), desc="Recognition"):
+            with tempfile.NamedTemporaryFile(
+                dir="/tmp",
+                delete=False,
+                prefix=f"xournalpp_htr__page{page_index}__",
+                suffix=".jpg",
+            ) as tmpfile:
+                TMP_FILE = Path(tmpfile.name)
+
+                written_file = document.save_page_as_image(
+                    page_index, TMP_FILE, False, dpi=RENDER_DPI
+                )
+
+                if (
+                    len(document.pages[page_index].layers) == 0
+                    or len(document.pages[page_index].layers[0].strokes) == 0
+                ):
+                    print(f"Page {page_index} is empty. Skipping HTR.")
+                    predictions[page_index] = []
+                    continue
+
+                img = cv2.imread(str(written_file), cv2.IMREAD_GRAYSCALE)
+
+                boxes = detector.detect(img)
+
+                coord_scale = document.DPI / RENDER_DPI
+                predictions_page = []
+                for box in boxes:
+                    x_min = max(0, int(box.x_min))
+                    y_min = max(0, int(box.y_min))
+                    x_max = min(img.shape[1], int(box.x_max))
+                    y_max = min(img.shape[0], int(box.y_max))
+
+                    crop = img[y_min:y_max, x_min:x_max]
+                    if crop.size == 0:
+                        continue
+
+                    text = recognizer.recognize(crop)
+
+                    predictions_page.append(
+                        WordPrediction(
+                            text=text,
+                            xmin=box.x_min * coord_scale,
+                            xmax=box.x_max * coord_scale,
+                            ymin=box.y_min * coord_scale,
+                            ymax=box.y_max * coord_scale,
+                        )
+                    )
                 predictions[page_index] = predictions_page
 
     else:


### PR DESCRIPTION
## Summary

Closes #121.

- Adds a new `2025-06-07_local_pipeline` in `xournalpp_htr/models.py` that wires our locally-trained `WordDetectorModel` and `SimpleHTRModel` (loaded from HF Hub as ONNX) into the existing `compute_predictions()` dispatcher: page render → word detection → per-word recognition → `WordPrediction` list in document units (72 DPI per ADR 005).
- Adds a slow integration test `test_main_local_pipeline` that runs the full `export_xournalpp_to_pdf_with_htr` flow against the new pipeline.
- Updates docs (`architecture.md`, `developer_guide.md`, `models/simple_htr.md`, `roadmap.md`) to describe the second pipeline and reflect that both detector and recogniser are now internalised.

Replacing the external `htr_pipeline` package entirely remains out of scope and is tracked in #125.

## Test plan

- [x] `make tests-not-slow` passes
- [x] `make tests-all` passes (incl. the new slow `test_main_local_pipeline`)
- [x] CLI run on all example `.xopp` files with `--pipeline 2025-06-07_local_pipeline` produces good results without errors