### PR TITLE
Rename local pipeline to correct year (2026)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,7 +79,7 @@ graph TD
 3. **Run HTR** -- `compute_predictions()` dispatches on the `--pipeline` argument to one of two implementations:
 
     - `2024-07-18_htr_pipeline` (default) -- The external `htr_pipeline` library processes each image: an ONNX word detector locates regions (scaled to 40%, 5px margin), DBSCAN groups detections into lines (discarding lines with fewer than 2 words), and a second ONNX model recognises each word via CTC decoding.
-    - `2025-06-07_local_pipeline` -- An in-house pipeline that loads our locally-trained ONNX models from HuggingFace Hub (`WordDetectorModel` + `SimpleHTRModel`, see `xournalpp_htr/inference_models.py`) and runs detection + per-word recognition without `htr_pipeline`. Replacing the external dependency entirely is tracked in #125.
+    - `2026-06-07_local_pipeline` -- An in-house pipeline that loads our locally-trained ONNX models from HuggingFace Hub (`WordDetectorModel` + `SimpleHTRModel`, see `xournalpp_htr/inference_models.py`) and runs detection + per-word recognition without `htr_pipeline`. Replacing the external dependency entirely is tracked in #125.
 
     Output is a dictionary mapping page indices to lists of predictions (text + bounding box coordinates in image pixels).
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -72,7 +72,7 @@ To benchmark a specific pipeline or change the output format:
 
 ```bash
 uv run python scripts/run_benchmark.py --pipeline 2024-07-18_htr_pipeline
-uv run python scripts/run_benchmark.py --pipeline 2025-06-07_local_pipeline
+uv run python scripts/run_benchmark.py --pipeline 2026-06-07_local_pipeline
 uv run python scripts/run_benchmark.py --format json
 ```
 

--- a/docs/models/simple_htr.md
+++ b/docs/models/simple_htr.md
@@ -213,7 +213,7 @@ print(text)
 - [x] Hyperparameter sweep script
 - [x] First training run and experiment log
 - [x] ONNX validation notebook
-- [x] Integrated into end-to-end pipeline with WordDetectorNet (`2025-06-07_local_pipeline`, issue #121)
+- [x] Integrated into end-to-end pipeline with WordDetectorNet (`2026-06-07_local_pipeline`, issue #121)
 
 ## Outlook
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,7 +26,7 @@ in-house implementation. Both components have now been internalized: the WordDet
 (see [explanation of model](https://lellep.xyz/blog/worddetectornet-visually-explained.html),
 [code](https://github.com/PellelNitram/xournalpp_htr/tree/master/xournalpp_htr/training/WordDetectorNN) and
 [demo](https://huggingface.co/spaces/PellelNitram/xournalpp_htr_WordDetectorNN)) and SimpleHTR, which
-are wired together into the `2025-06-07_local_pipeline` (issue #121). Fully removing the `htr_pipeline`
+are wired together into the `2026-06-07_local_pipeline` (issue #121). Fully removing the `htr_pipeline`
 dependency is tracked in #125. This transition away from `htr_pipeline` will not be backward compatible.
 
 ## Roadmap as of *2025-05-03*

--- a/tests/test_run_htr.py
+++ b/tests/test_run_htr.py
@@ -71,7 +71,7 @@ def test_main_local_pipeline(
     args = {
         "input_file": get_path_to_minimal_test_data,
         "output_file": tmp_path / Path("test_main_local.pdf"),
-        "pipeline": "2025-06-07_local_pipeline",
+        "pipeline": "2026-06-07_local_pipeline",
         "prediction_image_dir": None,
         "show_predictions": False,
         "small_text": False,

--- a/xournalpp_htr/models.py
+++ b/xournalpp_htr/models.py
@@ -96,7 +96,7 @@ def compute_predictions(
                         )
                 predictions[page_index] = predictions_page
 
-    elif pipeline_name == "2025-06-07_local_pipeline":
+    elif pipeline_name == "2026-06-07_local_pipeline":
         RENDER_DPI = 150
         nr_pages = len(document.pages)
 


### PR DESCRIPTION
Fixes #130.

#121 introduced the `2025-06-07_local_pipeline`, but it was added on June 7, **2026** — the year in the name was a typo. This renames it to `2026-06-07_local_pipeline` across code, tests, and docs:

- `xournalpp_htr/models.py` — pipeline dispatch
- `tests/test_run_htr.py` — test args
- `docs/architecture.md`, `docs/developer_guide.md`, `docs/models/simple_htr.md`, `docs/roadmap.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)