### PR TITLE
Document best performing model for each model

### DIFF
--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -69,10 +69,13 @@ Each `docs/models/<model_name>.md` page should contain, in order:
 2. **GPU training setup** — step-by-step from clone → install → dataset →
    train → eval → demo → export → validate → upload.
 3. **Inference** — minimal `from_pretrained()` usage example.
-4. **Experiments** — log of training experiments, newest first, using the
+4. **Best model** — checkpoint path, key metric and experiment reference of
+   the current overall best performing model. Update this section whenever a
+   new experiment beats the previous best.
+5. **Experiments** — log of training experiments, newest first, using the
    template below.
-5. **Current status** — what is implemented, known issues.
-6. **Outlook** — planned follow-ups.
+6. **Current status** — what is implemented, known issues.
+7. **Outlook** — planned follow-ups.
 
 ### Experiments log template
 
@@ -84,5 +87,9 @@ Each `docs/models/<model_name>.md` page should contain, in order:
 - **Command:** the exact training/eval command used.
 - **Results:** key metrics, path to artefacts under `experiments/`,
   TensorBoard run name.
+- **Best model:** checkpoint path and metric value of the best performing
+  model from this experiment (e.g. `experiments/exp1/run3/best.ckpt —
+  CER 4.2%`). If this is the overall best model across all experiments,
+  note that explicitly.
 - **Conclusion:** what was learned and what to try next.
 ```

--- a/docs/models/simple_htr.md
+++ b/docs/models/simple_htr.md
@@ -122,6 +122,13 @@ text = model.recognize(word_image_grayscale)
 print(text)
 ```
 
+## Best model
+
+Experiment 3, dropout=0.5, augmentation on — **CER 0.056, word accuracy 84.2%**.
+Checkpoint: `experiments/experiment3/do0.5_augtrue/best_model.pth`.
+Configuration: lr=0.0005, bs=64, dropout=0.5, augmentation enabled,
+epoch_max=200 (early stopping with patience 25).
+
 ## Experiments
 
 ### 2026-06-03 — Experiment 1: learning rate and batch size sweep

--- a/docs/models/word_detector.md
+++ b/docs/models/word_detector.md
@@ -225,6 +225,13 @@ pipeline (ADR 003), which contracts word-level boxes *and* transcriptions. The
 `WordDetectorModel` class is the integration point; wiring it into a full
 pipeline waits on a recognition stage that adds labels.
 
+## Best model
+
+Experiment 3, augmentation on, seed 42 — **F1 0.8896**.
+Checkpoint: `experiments/experiment3/augtrue_seed42/best_model.pth`.
+Configuration: bs=10, lr=0.001, augmentation enabled, epoch_max=10000
+(early stopping with patience 50).
+
 ## Experiments
 
 A log of training experiments run on this model. Each entry should capture


### PR DESCRIPTION
Closes #131

## Summary

- Add **Best model** section to `docs/models/word_detector.md` (F1 0.8896, experiment 3, aug on, seed 42)
- Add **Best model** section to `docs/models/simple_htr.md` (CER 0.056, 84.2% word acc, experiment 3, dropout=0.5, aug on)
- Update `docs/models/index.md` conventions: add Best model as a required docs section and add a Best model field to the experiments log template

## Test plan

- [x] Verified WordDetector best model against experiment artifacts on GPU machine
- [x] SimpleHTR best model confirmed from experiment log (artifacts were cleaned up after condensing into log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)