### PR TITLE
Evaluate 2024-07-18_htr_pipeline with a visual benchmark report

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -76,4 +76,20 @@ uv run python scripts/run_benchmark.py --pipeline 2026-06-07_local_pipeline
 uv run python scripts/run_benchmark.py --format json
 ```
 
-The benchmark reports precision, recall, and CER (case-sensitive and case-insensitive) over matched word pairs. See `xournalpp_htr/benchmark.py` and ADR 005 for details on the evaluation methodology.
+To inspect the predictions visually, pass an output file with `-o`/`--html-report`:
+
+```bash
+uv run python scripts/run_benchmark.py --html-report report.html
+```
+
+This renders every page of every benchmark sample and draws the pipeline's predictions on top of the handwriting, coloured by outcome: the text was read correctly, the text was misread, or the prediction has no ground truth word behind it. Ground truth words the pipeline did not find are underlined instead. The report is a single self-contained HTML file (roughly 1 MB for the current dataset) that needs no network access to view. Collecting the data and rendering the pages costs extra time, so it only happens when the flag is given.
+
+### Evaluation methodology
+
+The benchmark reports precision, recall, and CER (case-sensitive and case-insensitive).
+
+A prediction counts as having found a ground truth word when it covers at least 80% of that word's bounding box and is at most 8 times its area. Predictions and ground truth words are then paired greedily, one to one within a page, tightest fit first. Intersection over union is deliberately not the criterion: word detectors pad their boxes, and because IoU divides by the union, that padding is negligible on long words but overwhelming on short ones — a perfectly placed box around "is" scores about 0.2 and would be counted as both a miss and a false positive.
+
+Precision and recall are computed over these pairs, so they measure detection. CER is computed only over matched pairs, so a word the pipeline never found does not contribute to it — detection failures show up in recall, not in CER.
+
+See `xournalpp_htr/benchmark.py` for the implementation, and ADR 005 for the coordinate system that ground truth and predictions share.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
       - 004 Ground truth schema: 'ADRs/004_ground_truth_schema.md'
       - 005 Prediction bounding box coordinate system: 'ADRs/005_prediction_bounding_box_coordinate_system.md'
       - 006 Model registry and training environment: 'ADRs/006_model_registry_and_training_environment.md'
+      - 007 Model demos local only: 'ADRs/007_model_demos_local_only.md'
     - PoCs:
       - Simplify Installation with single file executable: 'PoCs/simplify_installation_with_single_file_executable.md'
   - Models:

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -2,8 +2,9 @@
 
 import argparse
 import json
+from pathlib import Path
 
-from xournalpp_htr.benchmark import run_benchmark
+from xournalpp_htr.benchmark import run_benchmark, write_html_report
 
 
 def parse_arguments(cli_string: None | str = None):
@@ -28,12 +29,29 @@ def parse_arguments(cli_string: None | str = None):
         default="human",
         help="Output format.",
     )
+    parser.add_argument(
+        "-o",
+        "--html-report",
+        type=Path,
+        required=False,
+        default=None,
+        help=(
+            "Write a self-contained HTML report with page renders, prediction "
+            "overlays and per-word analysis to this file. Passing it enables the "
+            "extra analysis, which is slower; omitting it keeps the plain run."
+        ),
+    )
     return vars(parser.parse_args(cli_string.split() if cli_string else None))
 
 
 if __name__ == "__main__":
     args = parse_arguments()
-    result = run_benchmark(args["pipeline"])
+    result = run_benchmark(
+        args["pipeline"], collect_details=args["html_report"] is not None
+    )
+
+    if args["html_report"] is not None:
+        write_html_report(result, args["html_report"])
 
     if args["format"] == "json":
         print(
@@ -47,6 +65,9 @@ if __name__ == "__main__":
                     "n_gt_words": result.n_gt_words,
                     "n_predicted_words": result.n_predicted_words,
                     "n_matched": result.n_matched,
+                    "html_report": str(args["html_report"])
+                    if args["html_report"]
+                    else None,
                 },
                 indent=2,
             )
@@ -61,3 +82,5 @@ if __name__ == "__main__":
         )
         print(f"CER      : {result.cer:.1%}  (case-sensitive)")
         print(f"CER      : {result.cer_case_insensitive:.1%}  (case-insensitive)")
+        if args["html_report"] is not None:
+            print(f"Report   : {args['html_report']}")

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,6 +1,21 @@
+from dataclasses import dataclass
+
 import pytest
 
-from xournalpp_htr.benchmark import GroundTruthWord, _cer, _iou, _match
+from xournalpp_htr.benchmark import (
+    BenchmarkResult,
+    GroundTruthWord,
+    PageDetail,
+    ReportData,
+    SampleDetail,
+    WordRow,
+    _cer,
+    _collect_pages,
+    _iou,
+    _match,
+    _matches,
+    write_html_report,
+)
 from xournalpp_htr.models import WordPrediction
 
 
@@ -54,6 +69,50 @@ def test_cer_empty_hypothesis():
     assert _cer("abc", "") == pytest.approx(1.0)
 
 
+# --- _matches ---
+
+
+def test_matches_identical_boxes():
+    assert _matches(gt(), pred())
+
+
+def test_matches_padded_prediction_around_short_word():
+    # The case IoU could not handle: a two letter word whose box is small
+    # enough that the detector's padding dominates. IoU here is only ~0.23.
+    g = gt(text="is", xmin=0, xmax=12, ymin=0, ymax=10)
+    p = pred(text="is", xmin=-6, xmax=18, ymin=-6, ymax=16)
+    assert _iou(g, p) < 0.3
+    assert _matches(g, p)
+
+
+def test_matches_rejects_partial_coverage():
+    # Prediction covers only half of the GT box.
+    g = gt(xmin=0, xmax=20, ymin=0, ymax=10)
+    p = pred(xmin=10, xmax=30, ymin=0, ymax=10)
+    assert not _matches(g, p)
+
+
+def test_matches_rejects_oversized_box():
+    # Fully covered, but the prediction is far larger than the word -- e.g. a
+    # box spanning a whole line.
+    g = gt(xmin=0, xmax=10, ymin=0, ymax=10)
+    p = pred(xmin=-5, xmax=400, ymin=-5, ymax=25)
+    assert not _matches(g, p)
+
+
+def test_matches_accepts_at_coverage_boundary():
+    # Exactly 80% of the GT box is covered.
+    g = gt(xmin=0, xmax=10, ymin=0, ymax=10)
+    p = pred(xmin=0, xmax=8, ymin=0, ymax=10)
+    assert _matches(g, p)
+
+
+def test_matches_zero_area_ground_truth():
+    # A single point annotation must not blow up the ratio computations.
+    g = gt(xmin=5, xmax=5, ymin=5, ymax=5)
+    assert not _matches(g, pred())
+
+
 # --- _match ---
 
 
@@ -103,3 +162,132 @@ def test_match_multiple_pages():
     p1 = pred(text="b")
     pairs = _match([g0, g1], {0: [p0], 1: [p1]})
     assert len(pairs) == 2
+
+
+# --- report details ---
+
+
+@dataclass
+class FakePage:
+    meta_data: dict
+    layers: list
+
+
+class FakeDocument:
+    """Stand-in for `Document` that renders a fixed byte string per page."""
+
+    def __init__(self, n_pages=1):
+        self.pages = [
+            FakePage(meta_data={"width": "595", "height": "842"}, layers=[])
+            for _ in range(n_pages)
+        ]
+
+    def save_page_as_image(self, page_index, out_path, black_white=False, dpi=72.0):
+        out_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+        return out_path
+
+
+def test_collect_pages_classifies_words():
+    g_correct = gt(text="hello", xmin=0, xmax=10, ymin=0, ymax=10)
+    g_wrong = gt(text="world", xmin=20, xmax=30, ymin=0, ymax=10)
+    g_missed = gt(text="miss", xmin=100, xmax=110, ymin=100, ymax=110)
+    p_correct = pred(text="hello", xmin=0, xmax=10, ymin=0, ymax=10)
+    p_wrong = pred(text="wor1d", xmin=20, xmax=30, ymin=0, ymax=10)
+    p_spurious = pred(text="ghost", xmin=200, xmax=210, ymin=200, ymax=210)
+
+    gt_words = [g_correct, g_wrong, g_missed]
+    predictions = {0: [p_correct, p_wrong, p_spurious]}
+    pages = _collect_pages(
+        FakeDocument(), gt_words, predictions, _match(gt_words, predictions)
+    )
+
+    assert len(pages) == 1
+    page = pages[0]
+    assert page.width == 595.0
+    assert page.height == 842.0
+    assert page.image_uri.startswith("data:image/png;base64,")
+
+    by_status = {row.status: row for row in page.rows}
+    assert set(by_status) == {"correct", "wrong", "missed", "spurious"}
+    assert by_status["correct"].pred_text == "hello"
+    assert by_status["wrong"].gt_text == "world"
+    assert by_status["wrong"].pred_text == "wor1d"
+    assert by_status["missed"].pred_text is None
+    assert by_status["missed"].pred_box is None
+    assert by_status["spurious"].gt_text is None
+    assert by_status["spurious"].gt_box is None
+
+
+def test_collect_pages_status_is_case_sensitive():
+    g = gt(text="Hello")
+    p = pred(text="hello")
+    pages = _collect_pages(FakeDocument(), [g], {0: [p]}, _match([g], {0: [p]}))
+    assert pages[0].rows[0].status == "wrong"
+
+
+def test_collect_pages_covers_pages_without_predictions():
+    g = gt(text="alone", page_index=1)
+    pages = _collect_pages(FakeDocument(n_pages=2), [g], {}, [])
+    assert [len(page.rows) for page in pages] == [0, 1]
+    assert pages[1].rows[0].status == "missed"
+
+
+# --- write_html_report ---
+
+
+def report_data(rows):
+    page = PageDetail(
+        page_index=0,
+        width=595.0,
+        height=842.0,
+        image_uri="data:image/png;base64,iVBORw0KGgo=",
+        rows=rows,
+    )
+    details = ReportData(
+        pipeline_name="test_pipeline",
+        git_sha="abc1234",
+        created_at="2026-08-08 12:00:00",
+    )
+    details.samples.append(SampleDetail(name="sample.xopp", pages=[page]))
+    return BenchmarkResult(0.5, 0.5, 0.1, 0.1, 4, 4, 2, details=details)
+
+
+def test_write_html_report_without_details_raises(tmp_path):
+    result = BenchmarkResult(0.0, 0.0, 0.0, 0.0, 0, 0, 0)
+    with pytest.raises(ValueError):
+        write_html_report(result, tmp_path / "report.html")
+
+
+def test_write_html_report_writes_self_contained_page(tmp_path):
+    rows = [
+        WordRow("correct", "hello", "hello", (0, 0, 10, 10), (0, 0, 10, 10)),
+        WordRow("wrong", "world", "wor1d", (20, 0, 30, 10), (20, 0, 30, 10)),
+        WordRow("missed", "miss", None, (40, 0, 50, 10), None),
+        WordRow("spurious", None, "ghost", None, (60, 0, 70, 10)),
+    ]
+    out = tmp_path / "nested" / "report.html"
+    assert write_html_report(report_data(rows), out) == out
+
+    content = out.read_text(encoding="utf-8")
+    assert content.startswith("<!doctype html>")
+    assert "test_pipeline" in content
+    assert "abc1234" in content
+    assert "sample.xopp" in content
+    assert "data:image/png;base64," in content
+    # Predictions are drawn, the unfound word is underlined instead.
+    assert "wor1d" in content
+    assert "<line" in content
+    # Nothing is loaded from outside the file.
+    assert "http://" not in content
+    assert "https://" not in content
+
+
+def test_write_html_report_escapes_text(tmp_path):
+    rows = [WordRow("wrong", "a<b>", "x&y", (0, 0, 10, 10), (0, 0, 10, 10))]
+    out = tmp_path / "report.html"
+    write_html_report(report_data(rows), out)
+
+    content = out.read_text(encoding="utf-8")
+    assert "&lt;b&gt;" in content
+    assert "x&amp;y" in content
+    assert "<b>" not in content

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -107,6 +107,22 @@ def test_matches_accepts_at_coverage_boundary():
     assert _matches(g, p)
 
 
+def test_matches_rejects_just_below_coverage_boundary():
+    # 79% covered -- one percent short of the boundary above.
+    g = gt(xmin=0, xmax=100, ymin=0, ymax=10)
+    p = pred(xmin=0, xmax=79, ymin=0, ymax=10)
+    assert not _matches(g, p)
+
+
+def test_matches_rejects_prediction_smaller_than_word():
+    # A box sitting inside the word, e.g. the detector split it in half. The
+    # criterion is one-directional: covering the prediction is not enough,
+    # the prediction has to cover the word.
+    g = gt(xmin=0, xmax=40, ymin=0, ymax=10)
+    p = pred(xmin=0, xmax=15, ymin=0, ymax=10)
+    assert not _matches(g, p)
+
+
 def test_matches_zero_area_ground_truth():
     # A single point annotation must not blow up the ratio computations.
     g = gt(xmin=5, xmax=5, ymin=5, ymax=5)
@@ -131,19 +147,27 @@ def test_match_no_overlap():
 
 
 def test_match_one_gt_two_preds_assigns_higher_iou():
+    # Both predictions cover the word, so both are acceptable matches; the
+    # tighter one has to win on IoU.
     g = gt(xmin=0, xmax=10, ymin=0, ymax=10)
     p_close = pred(xmin=0, xmax=10, ymin=0, ymax=10)  # iou=1.0
-    p_far = pred(xmin=5, xmax=15, ymin=0, ymax=10)  # iou<1.0
-    pairs = _match([g], {0: [p_close, p_far]})
+    p_padded = pred(xmin=-4, xmax=14, ymin=0, ymax=10)  # iou≈0.56
+    assert _matches(g, p_close) and _matches(g, p_padded)
+
+    pairs = _match([g], {0: [p_close, p_padded]})
     assert len(pairs) == 1
     assert pairs[0][1] is p_close
 
 
 def test_match_one_pred_two_gts_assigns_higher_iou():
+    # The prediction is an acceptable match for both words; it has to go to
+    # the one it fits tightest.
     g_close = gt(xmin=0, xmax=10, ymin=0, ymax=10)
-    g_far = gt(xmin=5, xmax=15, ymin=0, ymax=10)
+    g_inside = gt(xmin=2, xmax=9, ymin=2, ymax=9)
     p = pred(xmin=0, xmax=10, ymin=0, ymax=10)  # iou=1.0 with g_close
-    pairs = _match([g_close, g_far], {0: [p]})
+    assert _matches(g_close, p) and _matches(g_inside, p)
+
+    pairs = _match([g_close, g_inside], {0: [p]})
     assert len(pairs) == 1
     assert pairs[0][0] is g_close
 
@@ -223,6 +247,23 @@ def test_collect_pages_status_is_case_sensitive():
     p = pred(text="hello")
     pages = _collect_pages(FakeDocument(), [g], {0: [p]}, _match([g], {0: [p]}))
     assert pages[0].rows[0].status == "wrong"
+
+
+def test_collect_pages_distinguishes_equal_predictions():
+    # `WordPrediction` is a dataclass, so two identical predictions compare
+    # equal. Only one of them can be matched; the other has to come back as
+    # spurious rather than being conflated with it.
+    g = gt(text="hello")
+    p_first = pred(text="hello")
+    p_second = pred(text="hello")
+    assert p_first == p_second
+
+    predictions = {0: [p_first, p_second]}
+    pairs = _match([g], predictions)
+    assert len(pairs) == 1
+
+    rows = _collect_pages(FakeDocument(), [g], predictions, pairs)[0].rows
+    assert sorted(row.status for row in rows) == ["correct", "spurious"]
 
 
 def test_collect_pages_covers_pages_without_predictions():

--- a/uv.lock
+++ b/uv.lock
@@ -5092,6 +5092,14 @@ hf = [
     { name = "python-dotenv" },
     { name = "supabase" },
 ]
+training-simple-htr = [
+    { name = "gradio" },
+    { name = "hydra-core" },
+    { name = "onnx" },
+    { name = "tensorboard" },
+    { name = "torch" },
+    { name = "torchvision" },
+]
 training-word-detector = [
     { name = "gradio" },
     { name = "hydra-core" },
@@ -5113,14 +5121,17 @@ requires-dist = [
     { name = "beautifulsoup4" },
     { name = "gitpython" },
     { name = "gradio", marker = "extra == 'hf'" },
+    { name = "gradio", marker = "extra == 'training-simple-htr'" },
     { name = "gradio", marker = "extra == 'training-word-detector'" },
     { name = "htr-pipeline", directory = "external/htr_pipeline/HTRPipeline" },
     { name = "huggingface-hub" },
+    { name = "hydra-core", marker = "extra == 'training-simple-htr'" },
     { name = "hydra-core", marker = "extra == 'training-word-detector'" },
     { name = "jupyter", marker = "extra == 'dev'" },
     { name = "lxml" },
     { name = "matplotlib" },
     { name = "numpy" },
+    { name = "onnx", marker = "extra == 'training-simple-htr'" },
     { name = "onnx", marker = "extra == 'training-word-detector'" },
     { name = "onnxruntime" },
     { name = "opencv-python" },
@@ -5133,13 +5144,16 @@ requires-dist = [
     { name = "scikit-learn" },
     { name = "setuptools", specifier = "<80" },
     { name = "supabase", marker = "extra == 'hf'" },
+    { name = "tensorboard", marker = "extra == 'training-simple-htr'" },
     { name = "tensorboard", marker = "extra == 'training-word-detector'" },
     { name = "testcontainers", specifier = ">=4.14.1" },
+    { name = "torch", marker = "extra == 'training-simple-htr'", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torch", marker = "extra == 'training-word-detector'", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torchvision", marker = "extra == 'training-simple-htr'", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torchvision", marker = "extra == 'training-word-detector'", index = "https://download.pytorch.org/whl/cu128" },
     { name = "tqdm" },
 ]
-provides-extras = ["hf", "training-word-detector", "dev"]
+provides-extras = ["hf", "training-word-detector", "training-simple-htr", "dev"]
 
 [package.metadata.requires-dev]
 docs = [

--- a/xournalpp_htr/benchmark.py
+++ b/xournalpp_htr/benchmark.py
@@ -10,8 +10,18 @@ from xournalpp_htr.xio import load_benchmark
 # Annotation classes that carry a text transcription (per ground_truth.schema.json).
 _TEXT_CLASSES = {"word", "digit", "mathematical_expression"}
 
-# Minimum IoU to consider a prediction matched to a GT word.
-_IOU_THRESHOLD = 0.5
+# A prediction matches a ground truth word when it covers most of that word and
+# is not wildly larger than it.
+#
+# IoU is deliberately not used as the criterion. Word detectors pad their boxes
+# (see the `margin` in `compute_predictions`), and because IoU divides by the
+# union, that padding costs little on long words but is fatal on short ones: a
+# perfectly centred box around "is" scores ~0.2 purely because the word is
+# small. Coverage asks the question we actually care about -- did the pipeline
+# find this word? -- and is unaffected by padding. The area cap stops a single
+# oversized box, such as one spanning a whole line, from counting as a match.
+_MIN_COVERAGE = 0.8  # fraction of the GT box that must lie inside the prediction
+_MAX_AREA_RATIO = 8.0  # prediction area may exceed the GT area by at most this
 
 
 @dataclass
@@ -65,6 +75,7 @@ def _load_gt_words(gt_path, document) -> list[GroundTruthWord]:
 
 
 def _iou(a: GroundTruthWord, b: WordPrediction) -> float:
+    """Intersection over union. Ranks candidate matches, it does not accept them."""
     ix1 = max(a.xmin, b.xmin)
     iy1 = max(a.ymin, b.ymin)
     ix2 = min(a.xmax, b.xmax)
@@ -75,6 +86,20 @@ def _iou(a: GroundTruthWord, b: WordPrediction) -> float:
     area_a = (a.xmax - a.xmin) * (a.ymax - a.ymin)
     area_b = (b.xmax - b.xmin) * (b.ymax - b.ymin)
     return intersection / (area_a + area_b - intersection)
+
+
+def _matches(a: GroundTruthWord, b: WordPrediction) -> bool:
+    """Whether a prediction covers enough of a GT word to count as finding it."""
+    ix1 = max(a.xmin, b.xmin)
+    iy1 = max(a.ymin, b.ymin)
+    ix2 = min(a.xmax, b.xmax)
+    iy2 = min(a.ymax, b.ymax)
+    intersection = max(0.0, ix2 - ix1) * max(0.0, iy2 - iy1)
+    area_a = (a.xmax - a.xmin) * (a.ymax - a.ymin)
+    area_b = (b.xmax - b.xmin) * (b.ymax - b.ymin)
+    if area_a == 0.0:
+        return False
+    return intersection / area_a >= _MIN_COVERAGE and area_b / area_a <= _MAX_AREA_RATIO
 
 
 def _cer(reference: str, hypothesis: str) -> float:
@@ -96,13 +121,17 @@ def _match(
     gt_words: list[GroundTruthWord],
     predictions: dict[PageIndex, list[WordPrediction]],
 ) -> list[tuple[GroundTruthWord, WordPrediction]]:
-    """Greedy IoU matching: highest IoU pairs are matched first."""
+    """Greedily pair ground truth words with predictions, one to one per page.
+
+    Acceptable pairs are decided by `_matches`; among those, the pair with the
+    tightest fit (highest IoU) is taken first so that a prediction goes to the
+    word it sits on rather than to a neighbour it merely overlaps.
+    """
     candidates = []
     for gt in gt_words:
         for pred in predictions.get(gt.page_index, []):
-            iou = _iou(gt, pred)
-            if iou >= _IOU_THRESHOLD:
-                candidates.append((iou, gt, pred))
+            if _matches(gt, pred):
+                candidates.append((_iou(gt, pred), gt, pred))
 
     candidates.sort(key=lambda x: x[0], reverse=True)
 

--- a/xournalpp_htr/benchmark.py
+++ b/xournalpp_htr/benchmark.py
@@ -1,5 +1,11 @@
+import base64
+import html
 import json
-from dataclasses import dataclass
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
 
 import numpy as np
 
@@ -23,6 +29,11 @@ _TEXT_CLASSES = {"word", "digit", "mathematical_expression"}
 _MIN_COVERAGE = 0.8  # fraction of the GT box that must lie inside the prediction
 _MAX_AREA_RATIO = 8.0  # prediction area may exceed the GT area by at most this
 
+# Resolution at which page images are rendered into the HTML report.
+_REPORT_DPI = 150
+
+Box = tuple[float, float, float, float]  # xmin, ymin, xmax, ymax
+
 
 @dataclass
 class GroundTruthWord:
@@ -43,6 +54,48 @@ class BenchmarkResult:
     n_gt_words: int
     n_predicted_words: int
     n_matched: int
+    #: Only populated when `run_benchmark` is called with `collect_details=True`.
+    details: "ReportData | None" = None
+
+
+@dataclass
+class WordRow:
+    """A ground truth word, a prediction, or a matched pair thereof."""
+
+    #: "correct"  -- matched and the text is exactly right
+    #: "wrong"    -- matched but the text differs from the ground truth
+    #: "missed"   -- ground truth word without a matching prediction
+    #: "spurious" -- prediction without a matching ground truth word
+    status: str
+    gt_text: str | None
+    pred_text: str | None
+    gt_box: Box | None
+    pred_box: Box | None
+
+
+@dataclass
+class PageDetail:
+    page_index: int
+    width: float  # in document units (72 DPI)
+    height: float
+    image_uri: str  # base64 data URI of the rendered page
+    rows: list[WordRow]
+
+
+@dataclass
+class SampleDetail:
+    name: str
+    pages: list[PageDetail]
+
+
+@dataclass
+class ReportData:
+    """Everything the HTML report needs beyond the aggregate metrics."""
+
+    pipeline_name: str
+    git_sha: str
+    created_at: str
+    samples: list[SampleDetail] = field(default_factory=list)
 
 
 def _load_gt_words(gt_path, document) -> list[GroundTruthWord]:
@@ -145,7 +198,14 @@ def _match(
     return pairs
 
 
-def run_benchmark(pipeline_name: str) -> BenchmarkResult:
+def run_benchmark(pipeline_name: str, collect_details: bool = False) -> BenchmarkResult:
+    """Benchmark `pipeline_name` against the xournalpp_htr_benchmark dataset.
+
+    :param pipeline_name: Pipeline to run, see `compute_predictions`.
+    :param collect_details: Additionally collect the per-page data the HTML
+        report is built from, including a render of every page. This is
+        considerably slower, hence opt-in. Stored in `BenchmarkResult.details`.
+    """
     samples = load_benchmark()
 
     total_gt = 0
@@ -154,6 +214,16 @@ def run_benchmark(pipeline_name: str) -> BenchmarkResult:
     total_edit_chars = 0
     total_edit_chars_case_insensitive = 0
     total_gt_chars_matched = 0
+
+    details = (
+        ReportData(
+            pipeline_name=pipeline_name,
+            git_sha=_git_sha(),
+            created_at=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        )
+        if collect_details
+        else None
+    )
 
     for sample in samples:
         document = get_document(sample.xopp_path)
@@ -176,6 +246,14 @@ def run_benchmark(pipeline_name: str) -> BenchmarkResult:
                 _cer(gt_word.text.lower(), pred_word.text.lower()) * len(gt_word.text)
             )
 
+        if details is not None:
+            details.samples.append(
+                SampleDetail(
+                    name=sample.xopp_path.name,
+                    pages=_collect_pages(document, gt_words, predictions, pairs),
+                )
+            )
+
     precision = total_matched / total_pred if total_pred > 0 else 0.0
     recall = total_matched / total_gt if total_gt > 0 else 0.0
     cer = (
@@ -195,4 +273,293 @@ def run_benchmark(pipeline_name: str) -> BenchmarkResult:
         n_gt_words=total_gt,
         n_predicted_words=total_pred,
         n_matched=total_matched,
+        details=details,
     )
+
+
+# --- Detail collection -------------------------------------------------------
+
+
+def _git_sha() -> str:
+    """Short SHA of the checkout this code lives in, or "unknown"."""
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=Path(__file__).resolve().parent,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def _render_page_uri(document, page_index: int) -> str:
+    """Render a page to a PNG and return it as a base64 data URI."""
+    with tempfile.NamedTemporaryFile(
+        delete=False, prefix="xournalpp_htr__report__", suffix=".png"
+    ) as tmpfile:
+        path = Path(tmpfile.name)
+    try:
+        document.save_page_as_image(page_index, path, False, dpi=_REPORT_DPI)
+        encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+    finally:
+        path.unlink(missing_ok=True)
+    return f"data:image/png;base64,{encoded}"
+
+
+def _collect_pages(
+    document,
+    gt_words: list[GroundTruthWord],
+    predictions: dict[PageIndex, list[WordPrediction]],
+    pairs: list[tuple[GroundTruthWord, WordPrediction]],
+) -> list[PageDetail]:
+    """Build the per-page detail records, rendering each page image."""
+    matched_gt = {id(gt): pred for gt, pred in pairs}
+    matched_pred = {id(pred) for _, pred in pairs}
+
+    pages = []
+    for page_index in range(len(document.pages)):
+        rows: list[WordRow] = []
+
+        for gt_word in (w for w in gt_words if w.page_index == page_index):
+            pred_word = matched_gt.get(id(gt_word))
+            if pred_word is None:
+                status = "missed"
+            else:
+                status = "correct" if pred_word.text == gt_word.text else "wrong"
+            rows.append(
+                WordRow(
+                    status=status,
+                    gt_text=gt_word.text,
+                    pred_text=None if pred_word is None else pred_word.text,
+                    gt_box=(gt_word.xmin, gt_word.ymin, gt_word.xmax, gt_word.ymax),
+                    pred_box=None
+                    if pred_word is None
+                    else (
+                        pred_word.xmin,
+                        pred_word.ymin,
+                        pred_word.xmax,
+                        pred_word.ymax,
+                    ),
+                )
+            )
+
+        for pred_word in predictions.get(page_index, []):
+            if id(pred_word) in matched_pred:
+                continue
+            rows.append(
+                WordRow(
+                    status="spurious",
+                    gt_text=None,
+                    pred_text=pred_word.text,
+                    gt_box=None,
+                    pred_box=(
+                        pred_word.xmin,
+                        pred_word.ymin,
+                        pred_word.xmax,
+                        pred_word.ymax,
+                    ),
+                )
+            )
+
+        meta = document.pages[page_index].meta_data
+        pages.append(
+            PageDetail(
+                page_index=page_index,
+                width=float(meta["width"]),
+                height=float(meta["height"]),
+                image_uri=_render_page_uri(document, page_index),
+                rows=rows,
+            )
+        )
+    return pages
+
+
+# --- HTML report -------------------------------------------------------------
+
+
+_REPORT_CSS = """
+:root {
+  --bg: #ffffff; --fg: #1b1b1f; --muted: #6b6b76; --line: #e2e2e8;
+  --correct: #1a7f37; --wrong: #bc4c00; --missed: #d1242f; --spurious: #8250df;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #14141a; --fg: #eaeaf0; --muted: #9a9aa6; --line: #2c2c36;
+    --correct: #3fb950; --wrong: #ffa657; --missed: #ff7b72; --spurious: #d2a8ff;
+  }
+}
+* { box-sizing: border-box; }
+body { margin: 0; padding: 2rem 1.5rem 5rem; background: var(--bg); color: var(--fg);
+  font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+main { max-width: 1100px; margin: 0 auto; }
+h1 { font-size: 1.5rem; margin: 0 0 .3rem; }
+h2 { font-size: 1.05rem; margin: 2.5rem 0 .3rem; padding-top: .8rem;
+  border-top: 1px solid var(--line); }
+h3 { font-size: .9rem; font-weight: 600; color: var(--muted); margin: 1.2rem 0 .4rem; }
+.meta { color: var(--muted); font-size: .85rem; }
+.legend { display: flex; flex-wrap: wrap; gap: 1.2rem; font-size: .8rem;
+  color: var(--muted); margin: 1rem 0; }
+.legend > span { position: relative; }
+.swatch { display: inline-block; width: .8rem; height: .8rem; border-radius: 2px;
+  margin-right: .3rem; vertical-align: -1px; }
+.info { display: inline-flex; align-items: center; justify-content: center;
+  width: 1rem; height: 1rem; margin-left: .35rem; border-radius: 50%;
+  border: 1px solid var(--line); color: var(--muted); font-size: .7rem;
+  font-style: italic; font-weight: 700; cursor: help; vertical-align: -1px; }
+.info:hover, .info:focus { border-color: var(--fg); color: var(--fg); outline: none; }
+.tip { position: absolute; left: 0; top: calc(100% + .4rem); z-index: 10;
+  width: min(24rem, 80vw); padding: .6rem .7rem; border: 1px solid var(--line);
+  border-radius: 6px; background: var(--bg); color: var(--fg); font-size: .8rem;
+  line-height: 1.45; box-shadow: 0 6px 18px rgba(0, 0, 0, .18);
+  visibility: hidden; opacity: 0; transition: opacity .12s ease; }
+.legend > span:hover .tip, .info:focus + .tip { visibility: visible; opacity: 1; }
+.page { position: relative; border: 1px solid var(--line); border-radius: 6px;
+  overflow: hidden; background: #fff; }
+.page img { display: block; width: 100%; height: auto; }
+.page svg { position: absolute; inset: 0; width: 100%; height: 100%; }
+svg rect { fill: none; stroke-width: .8; }
+svg text { font-size: 7px; font-family: monospace; }
+svg .correct rect { stroke: var(--correct); }
+svg .correct text { fill: var(--correct); }
+svg .wrong rect { stroke: var(--wrong); }
+svg .wrong text { fill: var(--wrong); }
+svg .spurious rect { stroke: var(--spurious); stroke-dasharray: 3 2; }
+svg .spurious text { fill: var(--spurious); }
+svg .missed line { stroke: var(--missed); stroke-width: 1.5; }
+"""
+
+
+def _pct(value: float) -> str:
+    return f"{value:.1%}"
+
+
+def _legend() -> str:
+    entries = [
+        (
+            "var(--correct)",
+            "prediction, text correct",
+            f"The pipeline found this word -- its box contains at least "
+            f"{_MIN_COVERAGE:.0%} of the annotated word -- and read it exactly "
+            f"right. The comparison is case-sensitive, so &quot;Hello&quot; "
+            f"predicted as &quot;hello&quot; is counted as wrong, not correct.",
+        ),
+        (
+            "var(--wrong)",
+            "prediction, text wrong",
+            "The pipeline found this word but misread at least one character. "
+            "Detection is fine here, recognition is not: these words are the ones "
+            "that drive the character error rate (CER). Hover the box on the page "
+            "to compare the ground truth against the prediction.",
+        ),
+        (
+            "var(--spurious)",
+            "prediction without a ground truth word",
+            f"The pipeline predicted a word here, but no annotated word matches it. "
+            f"Either it fired on something that is not text -- only annotations of "
+            f"class word, digit or mathematical expression are ground truth, so "
+            f"drawings and separators are not -- or its box misses part of the "
+            f"word (less than {_MIN_COVERAGE:.0%} covered) or is more than "
+            f"{_MAX_AREA_RATIO:.0f}x larger than it. These lower precision.",
+        ),
+        (
+            "var(--missed)",
+            "ground truth word without a prediction (underlined)",
+            f"An annotated word the pipeline did not return, drawn as an underline "
+            f"beneath the handwriting because there is no prediction box to show. "
+            f"These lower recall. An underline sitting inside a dashed box means "
+            f"the word was detected but the box does not cover {_MIN_COVERAGE:.0%} "
+            f"of it, so it counts as both a miss and a spurious prediction.",
+        ),
+    ]
+    items = "".join(
+        f'<span><span class="swatch" style="background:{color}"></span>{label}'
+        f'<span class="info" tabindex="0" role="button" aria-label="More information">'
+        f'i</span><span class="tip" role="tooltip">{tip}</span></span>'
+        for color, label, tip in entries
+    )
+    return f'<div class="legend">{items}</div>'
+
+
+def _page_figure(page: PageDetail) -> str:
+    """A page render with the pipeline's predictions drawn on top.
+
+    Only predictions get a box -- the handwriting itself is already visible in
+    the render. Ground truth words the pipeline did not find are marked with an
+    underline instead.
+    """
+    groups = []
+    for row in page.rows:
+        if row.status == "missed":
+            x0, _, x1, y1 = row.gt_box  # type: ignore[misc]
+            shapes = [
+                f'<line x1="{x0:.1f}" y1="{y1:.1f}" x2="{x1:.1f}" y2="{y1:.1f}"/>'
+            ]
+        else:
+            x0, y0, x1, y1 = row.pred_box  # type: ignore[misc]
+            shapes = [
+                f'<rect x="{x0:.1f}" y="{y0:.1f}" '
+                f'width="{x1 - x0:.1f}" height="{y1 - y0:.1f}"/>',
+                f'<text x="{x0:.1f}" y="{y0 - 1.5:.1f}">'
+                f"{html.escape(row.pred_text or '')}</text>",
+            ]
+        title = html.escape(f"GT: {row.gt_text or '—'} | pred: {row.pred_text or '—'}")
+        shapes.insert(0, f"<title>{title}</title>")
+        groups.append(f'<g class="{row.status}">{"".join(shapes)}</g>')
+
+    return (
+        f'<div class="page">'
+        f'<img src="{page.image_uri}" alt="page render" loading="lazy">'
+        f'<svg viewBox="0 0 {page.width:.1f} {page.height:.1f}" '
+        f'preserveAspectRatio="none">{"".join(groups)}</svg></div>'
+    )
+
+
+def write_html_report(result: BenchmarkResult, out_path: Path) -> Path:
+    """Write a self-contained HTML report showing every benchmark page.
+
+    Each page of each benchmark sample is rendered once, with the ground truth
+    boxes and the pipeline's predictions drawn on top.
+
+    :param result: Result of `run_benchmark(..., collect_details=True)`.
+    :param out_path: File to write the report to.
+    :returns: `out_path`.
+    """
+    if result.details is None:
+        raise ValueError(
+            "No details collected -- run `run_benchmark(..., collect_details=True)`."
+        )
+    details = result.details
+
+    body = [
+        "<main>",
+        "<h1>xournalpp_htr benchmark report</h1>",
+        '<div class="meta">'
+        f"Pipeline <code>{html.escape(details.pipeline_name)}</code> · "
+        f"commit <code>{html.escape(details.git_sha)}</code> · "
+        f"{html.escape(details.created_at)}<br>"
+        f"precision {_pct(result.precision)} · recall {_pct(result.recall)} · "
+        f"CER {_pct(result.cer)} ({_pct(result.cer_case_insensitive)} "
+        f"case-insensitive)"
+        "</div>",
+        _legend(),
+    ]
+    for sample in details.samples:
+        body.append(f"<h2>{html.escape(sample.name)}</h2>")
+        for page in sample.pages:
+            body.append(f"<h3>Page {page.page_index + 1}</h3>")
+            body.append(_page_figure(page))
+    body.append("</main>")
+
+    document = (
+        "<!doctype html><html lang='en'><head><meta charset='utf-8'>"
+        "<meta name='viewport' content='width=device-width, initial-scale=1'>"
+        f"<title>Benchmark report — {html.escape(details.pipeline_name)}</title>"
+        f"<style>{_REPORT_CSS}</style></head><body>" + "".join(body) + "</body></html>"
+    )
+
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(document, encoding="utf-8")
+    return out_path


### PR DESCRIPTION
Closes #140.

Evaluates `2024-07-18_htr_pipeline` against the `xournalpp_htr_benchmark` dataset and adds the tooling used to do it.

## Results

| Metric | Value |
| --- | --- |
| Precision | 77.8% (147/189 predictions matched) |
| Recall | 69.7% (147/211 GT words matched) |
| CER, case-sensitive | 94.5% |
| CER, case-insensitive | 39.4% |

The gap between the two CER figures is a systematic casing mismatch, not a reading failure: the pipeline emits all-caps (`HELLO`, `THES`), while the ground truth is normally cased. The case-insensitive figure is the meaningful one.

## Changes

- **Matching criterion.** A prediction now counts as finding a word when it covers >=80% of the word's box and is <=8x its area, instead of IoU >= 0.5. Word detectors pad their boxes, and IoU divides by the union, so that padding was fatal on short words -- a perfectly placed box around "is" scores ~0.2 and was counted as both a miss and a false positive. Measured over the dataset, accepted matches top out at 7.4x the GT area and rejected oversized boxes start at 9.3x, so the cap sits in an empty band.
- **HTML report.** `scripts/run_benchmark.py -o report.html` renders every page with the predictions drawn on top, coloured by outcome, with unfound words underlined. Self-contained, ~1.2 MB. Without the flag the benchmark runs exactly as before.
- **Tests** for the criterion and the report. Two existing tie-breaking tests had been hollowed out by the criterion change -- their losing candidate is now rejected before ranking -- and are repaired.
- **Docs**: the developer guide describes the matching rule, which previously existed only in code.

Note that metrics from before this branch are not comparable with these, since the matching rule changed.