### PR TITLE
Highlight data donation checkbox in red

### DIFF
--- a/scripts/demo.py
+++ b/scripts/demo.py
@@ -198,9 +198,20 @@ def save_HTR_document_for_download(session_id):
 
 # --- Gradio UI Layout ---
 
+# Highlight the data donation checkbox in red. The visible box is the `div.form`
+# wrapper Gradio puts around a standalone Checkbox, not the element carrying
+# `elem_id`, hence the `:has()` selector to reach it.
+CSS = """
+.form:has(#donate-data-box),
+#donate-data-box {
+    border-color: #d32f2f;
+}
+"""
+
 with gr.Blocks(
     # theme=gr.themes.Soft(),
     title="Xournal++ HTR Demo",
+    css=CSS,
 ) as demo:
     gr.Markdown(
         """
@@ -257,6 +268,7 @@ with gr.Blocks(
     donate_data_checkbox = gr.Checkbox(
         label="Donate Data: Help us to improve our open-source models by donating your uploaded document. Everything will be released as open-source!",
         value=False,
+        elem_id="donate-data-box",
     )
 
     upload_button = gr.UploadButton(


### PR DESCRIPTION
Closes #141.

Draws attention to the data donation checkbox in the demo by recoloring its existing border red.

## Approach

Gradio wraps a standalone `Checkbox` in a `div.form`, and that wrapper — not the element carrying `elem_id` — is what draws the visible box. The rule therefore uses `:has()` to reach the wrapper from the component.

Only the border *color* changes; width, radius and padding stay at Gradio's defaults, so it reads as the existing box rather than an added one. Earlier, heavier variants (thick border, red fill, red heading) were tried and rejected as too flashy.

## Notes

- `:has()` needs Safari 15.4+ / Chrome 105+ / Firefox 121+. Older browsers drop the rule and fall back to the default grey border.
- The issue also mentions communicating "please help" in red. This PR covers the red box only; the existing checkbox label carries the wording.
- CSS-only change, no logic touched. Verified visually in a local UI-only copy of the demo; `make tests-not-slow` was not run.